### PR TITLE
rough cut of an optional type

### DIFF
--- a/optional.hpp
+++ b/optional.hpp
@@ -15,6 +15,8 @@ namespace mapbox { namespace util {
 
     template<typename T>
     class optional {
+        static_assert(!std::is_reference<T>::value, "optional doesn't support references");
+
         variant<none_t, T> variant_;
 
       public:
@@ -39,6 +41,10 @@ namespace mapbox { namespace util {
         T&       get() {
             return variant_.template get<T>();
         }
+
+        T const& operator *() const { return this->get() ; }
+        T        operator *()       { return this->get() ; }
+
 
         optional& operator = ( T const& v ) {
             variant_ = v;


### PR DESCRIPTION
This PR captures a discussion from yesterday involving @artemp and @kkaefer if it would be feasible to build an optional type on-top of variant. 

![bildschirmfoto 2014-08-27 um 10 12 04](https://cloud.githubusercontent.com/assets/1067895/4056937/f49eccc0-2dc1-11e4-922d-497572315890.png)

The code is meant as a (JFDI) PoC and if there's interest, I am happy to develop this into production quality code.

Usage is like this:

``` C++
#include "optional.hpp"

#include <iostream>

struct dummy {
    dummy(int m_1, int m_2) : m_1(m_1), m_2(m_2) {}
    int m_1;
    int m_2;

};

int main() {
    mapbox::util::optional<double> dbl_opt;

    std::cout << "double initialized: " << (!dbl_opt ? "n" : "y") << std::endl;
    dbl_opt = 3.1415;
    std::cout << "double initialized: " << (!dbl_opt ? "n" : "y") << std::endl;

    const double pi = dbl_opt.get();
    std::cout << "double optional contains: " << pi << std::endl;


    mapbox::util::optional<dummy> dummy_opt;
    std::cout << "dummy initialized: " << (!dummy_opt ? "n" : "y") << std::endl;

    // rvalues, baby!
    dummy_opt.emplace(1, 2);
    std::cout << "initialized: " << (!dummy_opt ? "n" : "y") << std::endl;

    dummy_opt.reset();
    std::cout << "initialized: " << (!dummy_opt ? "n" : "y") << std::endl;
}
```

cc: @artemp @kkaefer @springmeyer 
