### PR TITLE
Move static_max and variant_helper into detail namespace.

### DIFF
--- a/variant.hpp
+++ b/variant.hpp
@@ -176,7 +176,6 @@ struct result_of_binary_visit<F, V, typename enable_if_type<typename F::result_t
 };
 
 
-} // namespace detail
 
 
 template <std::size_t arg1, std::size_t... others>
@@ -263,8 +262,6 @@ struct variant_helper<>
     VARIANT_INLINE static void copy(const std::size_t, const void *, void *) {}
     VARIANT_INLINE static void direct_swap(const std::size_t, void *, void *) {}
 };
-
-namespace detail {
 
 template <typename T>
 struct unwrapper
@@ -574,11 +571,11 @@ class variant
 {
 private:
 
-    static const std::size_t data_size = static_max<sizeof(Types)...>::value;
-    static const std::size_t data_align = static_max<alignof(Types)...>::value;
+    static const std::size_t data_size = detail::static_max<sizeof(Types)...>::value;
+    static const std::size_t data_align = detail::static_max<alignof(Types)...>::value;
 
     using data_type = typename std::aligned_storage<data_size, data_align>::type;
-    using helper_type = variant_helper<Types...>;
+    using helper_type = detail::variant_helper<Types...>;
 
     std::size_t type_index;
     data_type data;


### PR DESCRIPTION
Those functions/classes don't need to be available from outside.