### PR TITLE
refine noexcept specifiers on constructors

### DIFF
--- a/test/t/variant.cpp
+++ b/test/t/variant.cpp
@@ -235,15 +235,26 @@ TEST_CASE( "implicit conversion to unsigned char", "[variant][implicit conversio
 
 struct dummy {};
 
+TEST_CASE( "implicit conversion to a suitable type", "[variant][implicit conversion]" ) {
+    using mapbox::util::variant;
+    CHECK_NOTHROW((variant<dummy, float, std::string>(123)).get<float>());
+    CHECK_NOTHROW((variant<dummy, float, std::string>("foo")).get<std::string>());
+}
+
+TEST_CASE( "value_traits for non-convertible type", "[variant::detail]" ) {
+    namespace detail = mapbox::util::detail;
+    using target_type = detail::value_traits<dummy, int>::target_type;
+    CHECK((std::is_same<target_type, void>::value) == true);
+}
+
 TEST_CASE( "Type indexing should work with variants with duplicated types", "[variant::detail]" ) {
     // Index is in reverse order
     REQUIRE((mapbox::util::detail::value_traits<bool, bool, int, double, std::string>::index == 3));
     REQUIRE((mapbox::util::detail::value_traits<int, bool, int, double, std::string>::index == 2));
     REQUIRE((mapbox::util::detail::value_traits<double, bool, int, double, std::string>::index == 1));
     REQUIRE((mapbox::util::detail::value_traits<std::string, bool, int, double, std::string>::index == 0));
-    // For the following two, the instantiation of value_traits should fail. How can we test that?
-    //REQUIRE((mapbox::util::detail::value_traits<dummy, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
-    //REQUIRE((mapbox::util::detail::value_traits<std::vector<int>, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
+    REQUIRE((mapbox::util::detail::value_traits<dummy, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
+    REQUIRE((mapbox::util::detail::value_traits<std::vector<int>, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
 }
 
 TEST_CASE( "variant default constructor", "[variant][default constructor]" ) {

--- a/test/t/variant.cpp
+++ b/test/t/variant.cpp
@@ -241,8 +241,9 @@ TEST_CASE( "Type indexing should work with variants with duplicated types", "[va
     REQUIRE((mapbox::util::detail::value_traits<int, bool, int, double, std::string>::index == 2));
     REQUIRE((mapbox::util::detail::value_traits<double, bool, int, double, std::string>::index == 1));
     REQUIRE((mapbox::util::detail::value_traits<std::string, bool, int, double, std::string>::index == 0));
-    REQUIRE((mapbox::util::detail::value_traits<dummy, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
-    REQUIRE((mapbox::util::detail::value_traits<std::vector<int>, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
+    // For the following two, the instantiation of value_traits should fail. How can we test that?
+    //REQUIRE((mapbox::util::detail::value_traits<dummy, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
+    //REQUIRE((mapbox::util::detail::value_traits<std::vector<int>, bool, int, double, std::string>::index == mapbox::util::detail::invalid_value));
 }
 
 TEST_CASE( "variant default constructor", "[variant][default constructor]" ) {

--- a/variant.hpp
+++ b/variant.hpp
@@ -828,7 +828,10 @@ public:
         return detail::binary_dispatcher<F, V, R, Types...>::apply(v0, v1, f);
     }
 
-    ~variant() noexcept(std::is_nothrow_destructible<std::tuple<Types...>>::value)
+    ~variant()
+#if !defined(__GNUC__) || (100 * __GNUC__ + __GNUC_MINOR__ >= 408)
+        noexcept(std::is_nothrow_destructible<std::tuple<Types...>>::value)
+#endif
     {
         helper_type::destroy(type_index, &data);
     }


### PR DESCRIPTION
Refs #61 

A couple additions to detail::value_traits:
```c++
bool is_direct = direct_index != invalid_value;
bool is_valid = index != invalid_value;
typedef value_type = remove_reference<T>; // do it here so there's less clutter on use
typedef target_type = tuple_element<index, tuple<Types...>>
```

Because of the `target_type`, instantiation of `value_traits<T, U>` fails if `!is_convertible<T, U>`. I use this for enabling conversion constructor overloads.

I had to comment two tests because of that, I don't know how to test for "substitution failure must be an error". I tried a few things, but always ended up with `invalid use of incomplete type in std::tuple_element<0ul, std::tuple<>>`.
