### PR TITLE
Fix operator<().

### DIFF
--- a/variant.hpp
+++ b/variant.hpp
@@ -850,8 +850,7 @@ public:
         assert(valid() && rhs.valid());
         if (this->get_type_index() != rhs.get_type_index())
         {
-            return this->get_type_index() < rhs.get_type_index();
-            // ^^ borrowed from boost::variant
+            return this->which() < rhs.which();
         }
         detail::comparer<variant, detail::less_comp> visitor(*this);
         return visit(rhs, visitor);


### PR DESCRIPTION
The comparison operator was using the wrong order when variants with different
types in them were compared. Both boost and the upcoming standard order the
types from left to right, but our implementation orders them right to left.

Boost has the function `which()` returning the index of a type in the typelist
as do we. (The upcoming standard calls this `index()`). But the comparison
operator was using `get_type_index()` which orders the types the other way
round.