### PR TITLE
Cleanup up handling of references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ On Unix systems compile and run the unit tests with `make test`.
 On Windows run `scripts/build-local.bat`.
 
 
+## Limitations
+
+* The `variant` can not hold references (something like `variant<int&>` is
+  no possible). You might want to try `std::reference_wrapper` instead.
+
+
 ## Benchmarks
 
 The benchmarks depend on:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ On Windows run `scripts/build-local.bat`.
 ## Limitations
 
 * The `variant` can not hold references (something like `variant<int&>` is
-  no possible). You might want to try `std::reference_wrapper` instead.
+  not possible). You might want to try `std::reference_wrapper` instead.
 
 
 ## Benchmarks

--- a/test/compilation_failure/no-reference.cpp
+++ b/test/compilation_failure/no-reference.cpp
@@ -1,0 +1,7 @@
+
+#include <variant.hpp>
+
+int main() {
+    mapbox::util::variant<double, int&, long> x{mapbox::util::no_init()};
+}
+

--- a/test/compilation_failure/no-reference.pattern
+++ b/test/compilation_failure/no-reference.pattern
@@ -1,0 +1,1 @@
+Variant can not hold reference types

--- a/test/t/variant.cpp
+++ b/test/t/variant.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <ostream>
@@ -369,5 +370,23 @@ TEST_CASE("variant should work with comparison operators") {
     REQUIRE_FALSE(a >= s);
     REQUIRE_FALSE(c >= s);
     REQUIRE_FALSE(t >= s);
+}
+
+TEST_CASE( "storing reference wrappers works" ) {
+    using variant_type = mapbox::util::variant<std::reference_wrapper<int>, std::reference_wrapper<double>>;
+
+    int a = 1;
+    variant_type v{std::ref(a)};
+    REQUIRE(v.get<int>() == 1);
+    a = 2;
+    REQUIRE(v.get<int>() == 2);
+
+    double b = 3.141;
+    v = std::ref(b);
+    REQUIRE(v.get<double>() == Approx(3.141));
+    b = 2.718;
+    REQUIRE(v.get<double>() == Approx(2.718));
+    a = 3;
+    REQUIRE(v.get<double>() == Approx(2.718));
 }
 

--- a/variant.hpp
+++ b/variant.hpp
@@ -545,6 +545,17 @@ private:
     Variant const& lhs_;
 };
 
+// True if Predicate matches for all of the types Ts
+template <template<typename> class Predicate, typename... Ts>
+struct static_all_of : std::is_same<std::tuple<std::true_type, typename Predicate<Ts>::type...>,
+                                    std::tuple<typename Predicate<Ts>::type..., std::true_type>>
+{};
+
+// True if Predicate matches for none of the types Ts
+template <template<typename> class Predicate, typename... Ts>
+struct static_none_of : std::is_same<std::tuple<std::false_type, typename Predicate<Ts>::type...>,
+                                     std::tuple<typename Predicate<Ts>::type..., std::false_type>>
+{};
 
 } // namespace detail
 
@@ -554,6 +565,7 @@ template <typename... Types>
 class variant
 {
     static_assert(sizeof...(Types) > 0, "Template parameter type list of variant can not be empty");
+    static_assert(detail::static_none_of<std::is_reference, Types...>::value, "Variant can not hold reference types. Maybe use std::reference?");
 
 private:
 
@@ -581,11 +593,11 @@ public:
 
     // http://isocpp.org/blog/2012/11/universal-references-in-c11-scott-meyers
     template <typename T, class = typename std::enable_if<
-                          detail::is_valid_type<typename std::remove_reference<T>::type, Types...>::value>::type>
+                          detail::is_valid_type<T, Types...>::value>::type>
     VARIANT_INLINE variant(T && val) noexcept
-        : type_index(detail::value_traits<typename std::remove_reference<T>::type, Types...>::index)
+        : type_index(detail::value_traits<T, Types...>::index)
     {
-        constexpr std::size_t index = sizeof...(Types) - detail::value_traits<typename std::remove_reference<T>::type, Types...>::index - 1;
+        constexpr std::size_t index = sizeof...(Types) - detail::value_traits<T, Types...>::index - 1;
         using target_type = typename std::tuple_element<index, std::tuple<Types...>>::type;
         new (&data) target_type(std::forward<T>(val)); // nothrow
     }


### PR DESCRIPTION
Storing references hasn't worked before. This commit documents the fact, adds a
static check for it and tests this case. We also test the recommended
alternative, which is to use std::reference_wrapper.