### PR TITLE
Deprecate static_visitor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ On Windows run `scripts/build-local.bat`.
 
 * The included implementation of `optional` is deprecated and will be removed
   in a future version. See https://github.com/mapbox/variant/issues/64.
+* Old versions of the code needed visitors to derive from `static_visitor`.
+  This is not needed any more and marked as deprecated. The `static_visitor`
+  class will be removed in future versions.
 
 
 ## Benchmarks

--- a/test/bench_variant.cpp
+++ b/test/bench_variant.cpp
@@ -43,7 +43,7 @@ struct Holder
 
 } // namespace test
 
-struct print : util::static_visitor<>
+struct print
 {
     template <typename T>
     void operator()(T const& val) const
@@ -68,7 +68,7 @@ struct dummy : boost::static_visitor<>
 };
 
 template <typename V>
-struct dummy2 : util::static_visitor<>
+struct dummy2
 {
     dummy2(V & v)
         : v_(v) {}

--- a/test/binary_visitor_test.cpp
+++ b/test/binary_visitor_test.cpp
@@ -57,7 +57,7 @@ struct string_to_number<bool>
     }
 };
 
-struct javascript_equal_visitor : util::static_visitor<bool>
+struct javascript_equal_visitor
 {
     template <typename T>
     bool operator()(T lhs, T rhs) const

--- a/test/our_variant_hello_world.cpp
+++ b/test/our_variant_hello_world.cpp
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-struct check : mapbox::util::static_visitor<>
+struct check
 {
     template <typename T>
     void operator()(T const& val) const

--- a/test/recursive_wrapper_test.cpp
+++ b/test/recursive_wrapper_test.cpp
@@ -36,7 +36,7 @@ struct binary_op
     }
 };
 
-struct print : util::static_visitor<void>
+struct print
 {
     template <typename T>
     void operator()(T const& val) const
@@ -46,7 +46,7 @@ struct print : util::static_visitor<void>
 };
 
 
-struct test : util::static_visitor<std::string>
+struct test
 {
     template <typename T>
     std::string operator()(T const& obj) const
@@ -55,7 +55,7 @@ struct test : util::static_visitor<std::string>
     }
 };
 
-struct calculator : public util::static_visitor<int>
+struct calculator
 {
 public:
 
@@ -77,7 +77,7 @@ public:
     }
 };
 
-struct to_string : public util::static_visitor<std::string>
+struct to_string
 {
 public:
 

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -37,7 +37,7 @@ struct binary_op
     }
 };
 
-struct print : util::static_visitor<void>
+struct print
 {
     template <typename T>
     void operator()(T const& val) const
@@ -47,7 +47,7 @@ struct print : util::static_visitor<void>
 };
 
 
-struct test : util::static_visitor<std::string>
+struct test
 {
     template <typename T>
     std::string operator()(T const& obj) const
@@ -56,7 +56,7 @@ struct test : util::static_visitor<std::string>
     }
 };
 
-struct calculator : public util::static_visitor<int>
+struct calculator
 {
 public:
 
@@ -78,7 +78,7 @@ public:
     }
 };
 
-struct to_string : public util::static_visitor<std::string>
+struct to_string
 {
 public:
 

--- a/variant.hpp
+++ b/variant.hpp
@@ -13,6 +13,20 @@
 
 #include "recursive_wrapper.hpp"
 
+// [[deprecated]] is only available in C++14, use this for the time being
+#if __cplusplus <= 201103L
+# ifdef __GNUC__
+#  define MAPBOX_VARIANT_DEPRECATED __attribute__((deprecated))
+# elif defined(_MSC_VER)
+#  define MAPBOX_VARIANT_DEPRECATED __declspec(deprecated)
+# else
+#  define MAPBOX_VARIANT_DEPRECATED
+# endif
+#else
+#  define MAPBOX_VARIANT_DEPRECATED [[deprecated]]
+#endif
+
+
 #ifdef _MSC_VER
  // https://msdn.microsoft.com/en-us/library/bw1hbe6y.aspx
  #ifdef NDEBUG
@@ -51,7 +65,7 @@ public:
 }; // class bad_variant_access
 
 template <typename R = void>
-struct static_visitor
+struct MAPBOX_VARIANT_DEPRECATED static_visitor
 {
     using result_type = R;
 protected:


### PR DESCRIPTION
Old versions of the code needed visitors to derive from static_visitor.
This is not needed any more and marked as deprecated. The static_visitor
class will be removed in future versions.