### PR TITLE
Remove unnecessary type alias.

### DIFF
--- a/variant.hpp
+++ b/variant.hpp
@@ -294,8 +294,7 @@ struct dispatcher;
 template <typename F, typename V, typename R, typename T, typename... Types>
 struct dispatcher<F, V, R, T, Types...>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& v, F && f)
+    VARIANT_INLINE static R apply_const(V const& v, F && f)
     {
         if (v. template is<T>())
         {
@@ -307,7 +306,7 @@ struct dispatcher<F, V, R, T, Types...>
         }
     }
 
-    VARIANT_INLINE static result_type apply(V & v, F && f)
+    VARIANT_INLINE static R apply(V & v, F && f)
     {
         if (v. template is<T>())
         {
@@ -323,13 +322,12 @@ struct dispatcher<F, V, R, T, Types...>
 template <typename F, typename V, typename R, typename T>
 struct dispatcher<F, V, R, T>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& v, F && f)
+    VARIANT_INLINE static R apply_const(V const& v, F && f)
     {
         return f(unwrapper<T>::apply_const(v. template get<T>()));
     }
 
-    VARIANT_INLINE static result_type apply(V & v, F && f)
+    VARIANT_INLINE static R apply(V & v, F && f)
     {
         return f(unwrapper<T>::apply(v. template get<T>()));
     }
@@ -342,8 +340,7 @@ struct binary_dispatcher_rhs;
 template <typename F, typename V, typename R, typename T0, typename T1, typename... Types>
 struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& lhs, V const& rhs, F && f)
+    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F && f)
     {
         if (rhs. template is<T1>()) // call binary functor
         {
@@ -356,7 +353,7 @@ struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
         }
     }
 
-    VARIANT_INLINE static result_type apply(V & lhs, V & rhs, F && f)
+    VARIANT_INLINE static R apply(V & lhs, V & rhs, F && f)
     {
         if (rhs. template is<T1>()) // call binary functor
         {
@@ -374,14 +371,13 @@ struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
 template <typename F, typename V, typename R, typename T0, typename T1>
 struct binary_dispatcher_rhs<F, V, R, T0, T1>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& lhs, V const& rhs, F && f)
+    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F && f)
     {
         return f(unwrapper<T0>::apply_const(lhs. template get<T0>()),
                  unwrapper<T1>::apply_const(rhs. template get<T1>()));
     }
 
-    VARIANT_INLINE static result_type apply(V & lhs, V & rhs, F && f)
+    VARIANT_INLINE static R apply(V & lhs, V & rhs, F && f)
     {
         return f(unwrapper<T0>::apply(lhs. template get<T0>()),
                  unwrapper<T1>::apply(rhs. template get<T1>()));
@@ -396,8 +392,7 @@ struct binary_dispatcher_lhs;
 template <typename F, typename V, typename R, typename T0, typename T1, typename... Types>
 struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& lhs, V const& rhs, F && f)
+    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F && f)
     {
         if (lhs. template is<T1>()) // call binary functor
         {
@@ -410,7 +405,7 @@ struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
         }
     }
 
-    VARIANT_INLINE static result_type apply(V & lhs, V & rhs, F && f)
+    VARIANT_INLINE static R apply(V & lhs, V & rhs, F && f)
     {
         if (lhs. template is<T1>()) // call binary functor
         {
@@ -428,14 +423,13 @@ struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
 template <typename F, typename V, typename R, typename T0, typename T1>
 struct binary_dispatcher_lhs<F, V, R, T0, T1>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& lhs, V const& rhs, F && f)
+    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F && f)
     {
         return f(unwrapper<T1>::apply_const(lhs. template get<T1>()),
                  unwrapper<T0>::apply_const(rhs. template get<T0>()));
     }
 
-    VARIANT_INLINE static result_type apply(V & lhs, V & rhs, F && f)
+    VARIANT_INLINE static R apply(V & lhs, V & rhs, F && f)
     {
         return f(unwrapper<T1>::apply(lhs. template get<T1>()),
                  unwrapper<T0>::apply(rhs. template get<T0>()));
@@ -450,8 +444,7 @@ struct binary_dispatcher;
 template <typename F, typename V, typename R, typename T, typename... Types>
 struct binary_dispatcher<F, V, R, T, Types...>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& v0, V const& v1, F && f)
+    VARIANT_INLINE static R apply_const(V const& v0, V const& v1, F && f)
     {
         if (v0. template is<T>())
         {
@@ -472,7 +465,7 @@ struct binary_dispatcher<F, V, R, T, Types...>
         return binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, std::forward<F>(f));
     }
 
-    VARIANT_INLINE static result_type apply(V & v0, V & v1, F && f)
+    VARIANT_INLINE static R apply(V & v0, V & v1, F && f)
     {
         if (v0. template is<T>())
         {
@@ -497,14 +490,13 @@ struct binary_dispatcher<F, V, R, T, Types...>
 template <typename F, typename V, typename R, typename T>
 struct binary_dispatcher<F, V, R, T>
 {
-    using result_type = R;
-    VARIANT_INLINE static result_type apply_const(V const& v0, V const& v1, F && f)
+    VARIANT_INLINE static R apply_const(V const& v0, V const& v1, F && f)
     {
         return f(unwrapper<T>::apply_const(v0. template get<T>()),
                  unwrapper<T>::apply_const(v1. template get<T>())); // call binary functor
     }
 
-    VARIANT_INLINE static result_type apply(V & v0, V & v1, F && f)
+    VARIANT_INLINE static R apply(V & v0, V & v1, F && f)
     {
         return f(unwrapper<T>::apply(v0. template get<T>()),
                  unwrapper<T>::apply(v1. template get<T>())); // call binary functor


### PR DESCRIPTION
This looks like a leftover from the time when we didn't have std::result_of.