### PR TITLE
Remove redundant copy-assignment

### DIFF
--- a/variant.hpp
+++ b/variant.hpp
@@ -634,22 +634,12 @@ class variant
         return *this;
     }
 
-    // conversions
-    // move-assign
+    // conversion assign
     template <typename T>
     VARIANT_INLINE variant<Types...>& operator=(T&& rhs) noexcept
     {
         variant<Types...> temp(std::forward<T>(rhs));
         move_assign(std::move(temp));
-        return *this;
-    }
-
-    // copy-assign
-    template <typename T>
-    VARIANT_INLINE variant<Types...>& operator=(T const& rhs)
-    {
-        variant<Types...> temp(rhs);
-        copy_assign(temp);
         return *this;
     }
 


### PR DESCRIPTION
The first definition of conversion assignment uses universal reference and forwarding and (IMHO) there's no need for an additional operator that only matches const references.
(And by the way the second definition used to copy-construct the object twice)