### PR TITLE
Disallow implicit conversions in constructor and assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ deps
 *.gcda
 *.gcno
 .ycm_extra_conf.pyc
+mason_packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".mason"]
+	path = .mason
+	url = https://github.com/mapbox/mason.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,40 +6,40 @@ sudo: false
 addons_shortcuts:
   addons_clang35: &clang35
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5', 'boost-latest' ]
-      packages: [ 'clang-3.5', 'llvm-3.5-dev', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
+      packages: [ 'clang-3.5', 'llvm-3.5-dev' ]
   addons_clang36: &clang36
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6', 'boost-latest' ]
-      packages: [ 'clang-3.6', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6' ]
+      packages: [ 'clang-3.6' ]
   addons_clang37: &clang37
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7', 'boost-latest' ]
-      packages: [ 'clang-3.7', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7' ]
+      packages: [ 'clang-3.7' ]
   addons_clang38: &clang38
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8', 'boost-latest' ]
-      packages: [ 'clang-3.8', 'libboost1.55-all-dev']
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8' ]
+      packages: [ 'clang-3.8']
   addons_clang39: &clang39
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise', 'boost-latest' ]
-      packages: [ 'clang-3.9', 'libboost1.55-all-dev']
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise' ]
+      packages: [ 'clang-3.9']
   addons_gcc47: &gcc47
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-4.7', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-4.7' ]
   addons_gcc48: &gcc48
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-4.8', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-4.8' ]
   addons_gcc49: &gcc49
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-4.9', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-4.9' ]
   addons_gcc5: &gcc5
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-5', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-5' ]
 
 matrix:
   include:
@@ -102,7 +102,6 @@ before_install:
  - if [[ $(uname -s) == 'Linux' ]]; then
      export PYTHONPATH=$(pwd)/.local/lib/python2.7/site-packages;
    else
-     brew install boost;
      export PYTHONPATH=$(pwd)/.local/lib/python/site-packages;
    fi
  - if [[ ${COVERAGE:-0} == 'True' ]]; then
@@ -112,11 +111,7 @@ before_install:
 install:
  - make test
  - make bench
- - if [[ $(uname -s) == 'Linux' ]]; then
-     make sizes /usr/include/boost/variant.hpp;
-   else
-     make sizes `brew --prefix`/include/boost/variant.hpp;
-   fi
+ - make sizes
  - scripts/run_compilation_failure_tests.sh
  - if [[ ${TEST_GYP_BUILD:-0} == 'True' ]]; then
      make clean;

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
+MASON = .mason/mason
+BOOST_VERSION = boost 1.60.0
+
 CXX := $(CXX)
 CXX_STD ?= c++11
 
-BOOST_LIBS = -lboost_timer -lboost_system -lboost_chrono
+BOOST_FLAGS = `$(MASON) cflags $(BOOST_VERSION)`
 RELEASE_FLAGS = -O3 -DNDEBUG -march=native -DSINGLE_THREADED -fvisibility-inlines-hidden
 DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions
 COMMON_FLAGS = -Wall -pedantic -Wextra -Wsign-compare -Wsign-conversion -Wshadow -Wunused-parameter -std=$(CXX_STD)
@@ -10,24 +13,17 @@ LDFLAGS := $(LDFLAGS)
 
 OS:=$(shell uname -s)
 ifeq ($(OS),Darwin)
-	CXXFLAGS += -stdlib=libc++
-	LDFLAGS += -stdlib=libc++ -F/ -framework CoreFoundation
-else
-    BOOST_LIBS += -lrt
-endif
-
-ifeq (sizes,$(firstword $(MAKECMDGOALS)))
-  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-  $(eval $(RUN_ARGS):;@:)
-  ifndef RUN_ARGS
-  $(error sizes target requires you pass full path to boost variant.hpp)
-  endif
-  .PHONY: $(RUN_ARGS)
+  CXXFLAGS += -stdlib=libc++
+  LDFLAGS += -stdlib=libc++ -F/ -framework CoreFoundation
 endif
 
 ALL_HEADERS = $(shell find include/mapbox/ '(' -name '*.hpp' ')')
 
 all: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
+
+mason_packages:
+	git submodule update --init .mason
+	$(MASON) install $(BOOST_VERSION)
 
 ./deps/gyp:
 	git clone --depth 1 https://chromium.googlesource.com/external/gyp.git ./deps/gyp
@@ -37,25 +33,25 @@ gyp: ./deps/gyp
 	make V=1 -C ./out tests
 	./out/Release/tests
 
-out/bench-variant-debug: Makefile test/bench_variant.cpp
+out/bench-variant-debug: Makefile mason_packages test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -pthreads $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -Itest/include -pthreads $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/bench-variant: Makefile test/bench_variant.cpp
+out/bench-variant: Makefile mason_packages test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/unique_ptr_test: Makefile test/unique_ptr_test.cpp
+out/unique_ptr_test: Makefile mason_packages test/unique_ptr_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/recursive_wrapper_test: Makefile test/recursive_wrapper_test.cpp
+out/recursive_wrapper_test: Makefile mason_packages test/recursive_wrapper_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/binary_visitor_test: Makefile test/binary_visitor_test.cpp
+out/binary_visitor_test: Makefile mason_packages test/binary_visitor_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
 	./out/bench-variant 100000
@@ -85,9 +81,9 @@ coverage:
 sizes: Makefile
 	mkdir -p ./out
 	@$(CXX) -o ./out/our_variant_hello_world.out include/mapbox/variant.hpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/our_variant_hello_world.out
-	@$(CXX) -o ./out/boost_variant_hello_world.out $(RUN_ARGS) -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/boost_variant_hello_world.out
+	@$(CXX) -o ./out/boost_variant_hello_world.out `$(MASON) prefix boost 1.60.0`/include/boost/variant.hpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world.out
 	@$(CXX) -o ./out/our_variant_hello_world ./test/our_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/our_variant_hello_world
-	@$(CXX) -o ./out/boost_variant_hello_world ./test/boost_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/boost_variant_hello_world
+	@$(CXX) -o ./out/boost_variant_hello_world ./test/boost_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)  $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world
 
 profile: out/bench-variant-debug
 	mkdir -p profiling/
@@ -104,8 +100,8 @@ clean:
 	rm -f *.gcda *.gcno
 
 pgo: out Makefile
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS) -pg -fprofile-generate
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -pg -fprofile-generate
 	./test-variant 500000 >/dev/null 2>/dev/null
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS) -fprofile-use
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -fprofile-use
 
 .PHONY: sizes test

--- a/README.md
+++ b/README.md
@@ -93,15 +93,6 @@ On Windows run `scripts/build-local.bat`.
 
 ## Benchmarks
 
-The benchmarks depend on:
-
- - Boost headers (for benchmarking against `boost::variant`)
- - Boost built with `--with-timer` (used for benchmark timing)
-
-On Unix systems set your boost includes and libs locations and run `make test`:
-
-    export LDFLAGS='-L/opt/boost/lib'
-    export CXXFLAGS='-I/opt/boost/include'
     make bench
 
 

--- a/test/bench_variant.cpp
+++ b/test/bench_variant.cpp
@@ -7,9 +7,9 @@
 #include <utility>
 #include <vector>
 
-#include <boost/timer/timer.hpp>
-#include <boost/variant.hpp>
+#include "auto_cpu_timer.hpp"
 
+#include <boost/variant.hpp>
 #include <mapbox/variant.hpp>
 
 #define TEXT_SHORT "Test"
@@ -139,12 +139,12 @@ int main(int argc, char** argv)
 
         {
             std::cerr << "custom variant: ";
-            boost::timer::auto_cpu_timer t;
+            auto_cpu_timer t;
             run_variant_test(NUM_RUNS);
         }
         {
             std::cerr << "boost variant: ";
-            boost::timer::auto_cpu_timer t;
+            auto_cpu_timer t;
             run_boost_test(NUM_RUNS);
         }
     }
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
             typedef thread_group::value_type value_type;
             thread_group tg;
             std::cerr << "custom variant: ";
-            boost::timer::auto_cpu_timer timer;
+            auto_cpu_timer timer;
             for (std::size_t i = 0; i < THREADS; ++i)
             {
                 tg.emplace_back(new std::thread(run_variant_test, NUM_RUNS));
@@ -170,7 +170,7 @@ int main(int argc, char** argv)
             typedef thread_group::value_type value_type;
             thread_group tg;
             std::cerr << "boost variant: ";
-            boost::timer::auto_cpu_timer timer;
+            auto_cpu_timer timer;
             for (std::size_t i = 0; i < THREADS; ++i)
             {
                 tg.emplace_back(new std::thread(run_boost_test, NUM_RUNS));

--- a/test/include/auto_cpu_timer.hpp
+++ b/test/include/auto_cpu_timer.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <chrono>
+#include <iostream>
+
+struct auto_cpu_timer {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+    auto_cpu_timer() : start(std::chrono::high_resolution_clock::now()) {
+    }
+    ~auto_cpu_timer() {
+        auto end = std::chrono::high_resolution_clock::now();
+        std::chrono::microseconds elapsed =
+            std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cerr << elapsed.count() << "us" << std::endl;
+    }
+};

--- a/test/recursive_wrapper_test.cpp
+++ b/test/recursive_wrapper_test.cpp
@@ -5,7 +5,7 @@
 #include <typeinfo>
 #include <utility>
 
-#include <boost/timer/timer.hpp>
+#include "auto_cpu_timer.hpp"
 
 #include <mapbox/variant.hpp>
 
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
 
     int total = 0;
     {
-        boost::timer::auto_cpu_timer t;
+        auto_cpu_timer t;
         for (std::size_t i = 0; i < NUM_ITER; ++i)
         {
             total += util::apply_visitor(test::calculator(), result);

--- a/test/t/issue21.cpp
+++ b/test/t/issue21.cpp
@@ -4,6 +4,8 @@
 #include <mapbox/variant.hpp>
 #include <mapbox/variant_io.hpp>
 
+#include <iostream>
+
 // https://github.com/mapbox/variant/issues/21
 
 static int count;
@@ -12,6 +14,10 @@ struct t1
 {
     int value;
     t1(int v) : value(v)
+    {
+        ++count;
+    }
+    t1(t1&& o) : value(o.value)
     {
         ++count;
     }
@@ -37,7 +43,7 @@ TEST_CASE("set() works cleanly even if the constructor throws ", "[variant]")
 
     count = 0;
     {
-        variant_type v{42};
+        variant_type v{t1(42)};
         REQUIRE(v.is<t1>());
         REQUIRE(v.get<t1>().value == 42);
         REQUIRE_THROWS({

--- a/test/t/unary_visitor.cpp
+++ b/test/t/unary_visitor.cpp
@@ -34,7 +34,7 @@ TEST_CASE("non-const visitor works on const variants", "[visitor][unary visitor]
     using variant_type = const mapbox::util::variant<int, double, std::string>;
     variant_type var1(123);
     variant_type var2(3.2);
-    variant_type var3("foo");
+    variant_type var3(std::string("foo"));
     REQUIRE(var1.get<int>() == 123);
     REQUIRE(var2.get<double>() == Approx(3.2));
     REQUIRE(var3.get<std::string>() == "foo");
@@ -51,7 +51,7 @@ TEST_CASE("const visitor works on const variants", "[visitor][unary visitor]")
     using variant_type = const mapbox::util::variant<int, double, std::string>;
     variant_type var1(123);
     variant_type var2(3.2);
-    variant_type var3("foo");
+    variant_type var3(std::string("foo"));
     REQUIRE(var1.get<int>() == 123);
     REQUIRE(var2.get<double>() == Approx(3.2));
     REQUIRE(var3.get<std::string>() == "foo");
@@ -68,7 +68,7 @@ TEST_CASE("rvalue visitor works on const variants", "[visitor][unary visitor]")
     using variant_type = const mapbox::util::variant<int, double, std::string>;
     variant_type var1(123);
     variant_type var2(3.2);
-    variant_type var3("foo");
+    variant_type var3(std::string("foo"));
     REQUIRE(var1.get<int>() == 123);
     REQUIRE(var2.get<double>() == Approx(3.2));
     REQUIRE(var3.get<std::string>() == "foo");
@@ -84,7 +84,7 @@ TEST_CASE("visitor works on rvalue variants", "[visitor][unary visitor]")
 
     REQUIRE(mapbox::util::apply_visitor(some_visitor{1}, variant_type{123}) == 124);
     REQUIRE(mapbox::util::apply_visitor(some_visitor{1}, variant_type{3.2}) == 4);
-    REQUIRE(mapbox::util::apply_visitor(some_visitor{1}, variant_type{"foo"}) == 0);
+    REQUIRE(mapbox::util::apply_visitor(some_visitor{1}, variant_type{std::string("foo")}) == 0);
 }
 
 struct total_sizeof
@@ -120,7 +120,7 @@ TEST_CASE("changes in visitor should be visible", "[visitor][unary visitor]")
 TEST_CASE("changes in const visitor (with mutable internals) should be visible", "[visitor][unary visitor]")
 {
     using variant_type = const mapbox::util::variant<int, std::string, double>;
-    variant_type v{"foo"};
+    variant_type v{std::string("foo")};
     const total_sizeof ts;
     REQUIRE(mapbox::util::apply_visitor(ts, v) == sizeof(std::string));
     REQUIRE(ts.result() == sizeof(std::string));

--- a/test/t/variant.cpp
+++ b/test/t/variant.cpp
@@ -313,44 +313,16 @@ TEST_CASE("no_init variant can be copied and moved to", "[variant]")
     REQUIRE(v3.get<int>() == 42);
 }
 
-TEST_CASE("implicit conversion", "[variant][implicit conversion]")
+TEST_CASE("no implicit conversion", "[variant][implicit conversion]")
 {
     using variant_type = mapbox::util::variant<int>;
-    variant_type var(5.0); // converted to int
-    REQUIRE(var.get<int>() == 5);
-    var = 6.0; // works for operator=, too
-    REQUIRE(var.get<int>() == 6);
-}
-
-TEST_CASE("implicit conversion to first type in variant type list", "[variant][implicit conversion]")
-{
-    using variant_type = mapbox::util::variant<long, char>;
-    variant_type var = 5.0; // converted to long
-    REQUIRE(var.get<long>() == 5);
-    REQUIRE_THROWS_AS({
-        var.get<char>();
-    },
-                      mapbox::util::bad_variant_access&);
-}
-
-TEST_CASE("implicit conversion to unsigned char", "[variant][implicit conversion]")
-{
-    using variant_type = mapbox::util::variant<unsigned char>;
-    variant_type var = 100.0;
-    CHECK(var.get<unsigned char>() == static_cast<unsigned char>(100.0));
-    CHECK(var.get<unsigned char>() == static_cast<unsigned char>(static_cast<unsigned int>(100.0)));
+    REQUIRE((!std::is_constructible<variant_type, double>::value));
+    REQUIRE((!std::is_assignable<variant_type, double>::value));
 }
 
 struct dummy
 {
 };
-
-TEST_CASE("implicit conversion to a suitable type", "[variant][implicit conversion]")
-{
-    using mapbox::util::variant;
-    CHECK_NOTHROW((variant<dummy, float, std::string>(123)).get<float>());
-    CHECK_NOTHROW((variant<dummy, float, std::string>("foo")).get<std::string>());
-}
 
 TEST_CASE("value_traits for non-convertible type", "[variant::detail]")
 {
@@ -387,7 +359,7 @@ TEST_CASE("variant default constructor", "[variant][default constructor]")
 TEST_CASE("variant printer", "[visitor][unary visitor][printer]")
 {
     using variant_type = mapbox::util::variant<int, double, std::string>;
-    std::vector<variant_type> var = {2.1, 123, "foo", 456};
+    std::vector<variant_type> var = {2.1, 123, std::string("foo"), 456};
     std::stringstream out;
     std::copy(var.begin(), var.end(), std::ostream_iterator<variant_type>(out, ","));
     out << var[2];
@@ -400,8 +372,8 @@ TEST_CASE("swapping variants should do the right thing", "[variant]")
     variant_type a = 7;
     variant_type b = 3;
     variant_type c = 3.141;
-    variant_type d = "foo";
-    variant_type e = "a long string that is longer than small string optimization";
+    variant_type d = std::string("foo");
+    variant_type e = std::string("a long string that is longer than small string optimization");
 
     using std::swap;
     swap(a, b);
@@ -436,7 +408,7 @@ TEST_CASE("variant should work with equality operators")
     variant_type a{1};
     variant_type b{1};
     variant_type c{2};
-    variant_type s{"foo"};
+    variant_type s{std::string("foo")};
 
     REQUIRE(a == a);
     REQUIRE(a == b);
@@ -458,8 +430,8 @@ TEST_CASE("variant should work with comparison operators")
     variant_type a{1};
     variant_type b{1};
     variant_type c{2};
-    variant_type s{"foo"};
-    variant_type t{"bar"};
+    variant_type s{std::string("foo")};
+    variant_type t{std::string("bar")};
 
     REQUIRE_FALSE(a < a);
     REQUIRE_FALSE(a < b);

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -6,7 +6,7 @@
 #include <typeinfo>
 #include <utility>
 
-#include <boost/timer/timer.hpp>
+#include "auto_cpu_timer.hpp"
 
 #include <mapbox/variant.hpp>
 
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
 
     int total = 0;
     {
-        boost::timer::auto_cpu_timer t;
+        auto_cpu_timer t;
         for (std::size_t i = 0; i < NUM_ITER; ++i)
         {
             total += util::apply_visitor(test::calculator(), result);


### PR DESCRIPTION
Fixes #100.

This should be considered a breaking change, to be released as 2.0. I can hit some of the other 2.0 changes like removing deprecated parts and [tagged issues](https://github.com/mapbox/variant/issues?q=is%3Aissue+is%3Aopen+label%3A%22interface+change%22).

cc @artemp @springmeyer @joto 