### PR TITLE
Install boost with mason; eliminate boost::timer dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ deps
 *.gcda
 *.gcno
 .ycm_extra_conf.pyc
+mason_packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".mason"]
+	path = .mason
+	url = https://github.com/mapbox/mason.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,40 +6,40 @@ sudo: false
 addons_shortcuts:
   addons_clang35: &clang35
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5', 'boost-latest' ]
-      packages: [ 'clang-3.5', 'llvm-3.5-dev', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
+      packages: [ 'clang-3.5', 'llvm-3.5-dev' ]
   addons_clang36: &clang36
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6', 'boost-latest' ]
-      packages: [ 'clang-3.6', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6' ]
+      packages: [ 'clang-3.6' ]
   addons_clang37: &clang37
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7', 'boost-latest' ]
-      packages: [ 'clang-3.7', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7' ]
+      packages: [ 'clang-3.7' ]
   addons_clang38: &clang38
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8', 'boost-latest' ]
-      packages: [ 'clang-3.8', 'libboost1.55-all-dev']
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8' ]
+      packages: [ 'clang-3.8']
   addons_clang39: &clang39
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise', 'boost-latest' ]
-      packages: [ 'clang-3.9', 'libboost1.55-all-dev']
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise' ]
+      packages: [ 'clang-3.9']
   addons_gcc47: &gcc47
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-4.7', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-4.7' ]
   addons_gcc48: &gcc48
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-4.8', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-4.8' ]
   addons_gcc49: &gcc49
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-4.9', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-4.9' ]
   addons_gcc5: &gcc5
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'boost-latest' ]
-      packages: [ 'g++-5', 'libboost1.55-all-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-5' ]
 
 matrix:
   include:
@@ -102,7 +102,6 @@ before_install:
  - if [[ $(uname -s) == 'Linux' ]]; then
      export PYTHONPATH=$(pwd)/.local/lib/python2.7/site-packages;
    else
-     brew install boost;
      export PYTHONPATH=$(pwd)/.local/lib/python/site-packages;
    fi
  - if [[ ${COVERAGE:-0} == 'True' ]]; then
@@ -112,11 +111,7 @@ before_install:
 install:
  - make test
  - make bench
- - if [[ $(uname -s) == 'Linux' ]]; then
-     make sizes /usr/include/boost/variant.hpp;
-   else
-     make sizes `brew --prefix`/include/boost/variant.hpp;
-   fi
+ - make sizes
  - scripts/run_compilation_failure_tests.sh
  - if [[ ${TEST_GYP_BUILD:-0} == 'True' ]]; then
      make clean;

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
+MASON = .mason/mason
+BOOST_VERSION = boost 1.60.0
+
 CXX := $(CXX)
 CXX_STD ?= c++11
 
-BOOST_LIBS = -lboost_timer -lboost_system -lboost_chrono
+BOOST_FLAGS = `$(MASON) cflags $(BOOST_VERSION)`
 RELEASE_FLAGS = -O3 -DNDEBUG -march=native -DSINGLE_THREADED -fvisibility-inlines-hidden
 DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions
 COMMON_FLAGS = -Wall -pedantic -Wextra -Wsign-compare -Wsign-conversion -Wshadow -Wunused-parameter -std=$(CXX_STD)
@@ -10,24 +13,17 @@ LDFLAGS := $(LDFLAGS)
 
 OS:=$(shell uname -s)
 ifeq ($(OS),Darwin)
-	CXXFLAGS += -stdlib=libc++
-	LDFLAGS += -stdlib=libc++ -F/ -framework CoreFoundation
-else
-    BOOST_LIBS += -lrt
-endif
-
-ifeq (sizes,$(firstword $(MAKECMDGOALS)))
-  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-  $(eval $(RUN_ARGS):;@:)
-  ifndef RUN_ARGS
-  $(error sizes target requires you pass full path to boost variant.hpp)
-  endif
-  .PHONY: $(RUN_ARGS)
+  CXXFLAGS += -stdlib=libc++
+  LDFLAGS += -stdlib=libc++ -F/ -framework CoreFoundation
 endif
 
 ALL_HEADERS = $(shell find include/mapbox/ '(' -name '*.hpp' ')')
 
 all: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
+
+mason_packages:
+	git submodule update --init .mason
+	$(MASON) install $(BOOST_VERSION)
 
 ./deps/gyp:
 	git clone --depth 1 https://chromium.googlesource.com/external/gyp.git ./deps/gyp
@@ -37,25 +33,25 @@ gyp: ./deps/gyp
 	make V=1 -C ./out tests
 	./out/Release/tests
 
-out/bench-variant-debug: Makefile test/bench_variant.cpp
+out/bench-variant-debug: Makefile mason_packages test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -pthreads $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -Itest/include -pthreads $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/bench-variant: Makefile test/bench_variant.cpp
+out/bench-variant: Makefile mason_packages test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/unique_ptr_test: Makefile test/unique_ptr_test.cpp
+out/unique_ptr_test: Makefile mason_packages test/unique_ptr_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/recursive_wrapper_test: Makefile test/recursive_wrapper_test.cpp
+out/recursive_wrapper_test: Makefile mason_packages test/recursive_wrapper_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
-out/binary_visitor_test: Makefile test/binary_visitor_test.cpp
+out/binary_visitor_test: Makefile mason_packages test/binary_visitor_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS)
+	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
 	./out/bench-variant 100000
@@ -85,9 +81,9 @@ coverage:
 sizes: Makefile
 	mkdir -p ./out
 	@$(CXX) -o ./out/our_variant_hello_world.out include/mapbox/variant.hpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/our_variant_hello_world.out
-	@$(CXX) -o ./out/boost_variant_hello_world.out $(RUN_ARGS) -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/boost_variant_hello_world.out
+	@$(CXX) -o ./out/boost_variant_hello_world.out `$(MASON) prefix boost 1.60.0`/include/boost/variant.hpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world.out
 	@$(CXX) -o ./out/our_variant_hello_world ./test/our_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/our_variant_hello_world
-	@$(CXX) -o ./out/boost_variant_hello_world ./test/boost_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/boost_variant_hello_world
+	@$(CXX) -o ./out/boost_variant_hello_world ./test/boost_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)  $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world
 
 profile: out/bench-variant-debug
 	mkdir -p profiling/
@@ -104,8 +100,8 @@ clean:
 	rm -f *.gcda *.gcno
 
 pgo: out Makefile
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS) -pg -fprofile-generate
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -pg -fprofile-generate
 	./test-variant 500000 >/dev/null 2>/dev/null
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_LIBS) -fprofile-use
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -fprofile-use
 
 .PHONY: sizes test

--- a/README.md
+++ b/README.md
@@ -93,15 +93,6 @@ On Windows run `scripts/build-local.bat`.
 
 ## Benchmarks
 
-The benchmarks depend on:
-
- - Boost headers (for benchmarking against `boost::variant`)
- - Boost built with `--with-timer` (used for benchmark timing)
-
-On Unix systems set your boost includes and libs locations and run `make test`:
-
-    export LDFLAGS='-L/opt/boost/lib'
-    export CXXFLAGS='-I/opt/boost/include'
     make bench
 
 

--- a/test/bench_variant.cpp
+++ b/test/bench_variant.cpp
@@ -7,9 +7,9 @@
 #include <utility>
 #include <vector>
 
-#include <boost/timer/timer.hpp>
-#include <boost/variant.hpp>
+#include "auto_cpu_timer.hpp"
 
+#include <boost/variant.hpp>
 #include <mapbox/variant.hpp>
 
 #define TEXT_SHORT "Test"
@@ -139,12 +139,12 @@ int main(int argc, char** argv)
 
         {
             std::cerr << "custom variant: ";
-            boost::timer::auto_cpu_timer t;
+            auto_cpu_timer t;
             run_variant_test(NUM_RUNS);
         }
         {
             std::cerr << "boost variant: ";
-            boost::timer::auto_cpu_timer t;
+            auto_cpu_timer t;
             run_boost_test(NUM_RUNS);
         }
     }
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
             typedef thread_group::value_type value_type;
             thread_group tg;
             std::cerr << "custom variant: ";
-            boost::timer::auto_cpu_timer timer;
+            auto_cpu_timer timer;
             for (std::size_t i = 0; i < THREADS; ++i)
             {
                 tg.emplace_back(new std::thread(run_variant_test, NUM_RUNS));
@@ -170,7 +170,7 @@ int main(int argc, char** argv)
             typedef thread_group::value_type value_type;
             thread_group tg;
             std::cerr << "boost variant: ";
-            boost::timer::auto_cpu_timer timer;
+            auto_cpu_timer timer;
             for (std::size_t i = 0; i < THREADS; ++i)
             {
                 tg.emplace_back(new std::thread(run_boost_test, NUM_RUNS));

--- a/test/include/auto_cpu_timer.hpp
+++ b/test/include/auto_cpu_timer.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <chrono>
+#include <iostream>
+
+struct auto_cpu_timer {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+    auto_cpu_timer() : start(std::chrono::high_resolution_clock::now()) {
+    }
+    ~auto_cpu_timer() {
+        auto end = std::chrono::high_resolution_clock::now();
+        std::chrono::microseconds elapsed =
+            std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cerr << elapsed.count() << "us" << std::endl;
+    }
+};

--- a/test/recursive_wrapper_test.cpp
+++ b/test/recursive_wrapper_test.cpp
@@ -5,7 +5,7 @@
 #include <typeinfo>
 #include <utility>
 
-#include <boost/timer/timer.hpp>
+#include "auto_cpu_timer.hpp"
 
 #include <mapbox/variant.hpp>
 
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
 
     int total = 0;
     {
-        boost::timer::auto_cpu_timer t;
+        auto_cpu_timer t;
         for (std::size_t i = 0; i < NUM_ITER; ++i)
         {
             total += util::apply_visitor(test::calculator(), result);

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -6,7 +6,7 @@
 #include <typeinfo>
 #include <utility>
 
-#include <boost/timer/timer.hpp>
+#include "auto_cpu_timer.hpp"
 
 #include <mapbox/variant.hpp>
 
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
 
     int total = 0;
     {
-        boost::timer::auto_cpu_timer t;
+        auto_cpu_timer t;
         for (std::size_t i = 0; i < NUM_ITER; ++i)
         {
             total += util::apply_visitor(test::calculator(), result);


### PR DESCRIPTION
Fixes #105

cc @springmeyer @artemp 