### PR TITLE
Add get_unchecked<type>()

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -299,7 +299,7 @@ struct dispatcher<F, V, R, T, Types...>
     {
         if (v.template is<T>())
         {
-            return f(unwrapper<T>::apply_const(v.template get<T>()));
+            return f(unwrapper<T>::apply_const(v.template get_unchecked<T>()));
         }
         else
         {
@@ -311,7 +311,7 @@ struct dispatcher<F, V, R, T, Types...>
     {
         if (v.template is<T>())
         {
-            return f(unwrapper<T>::apply(v.template get<T>()));
+            return f(unwrapper<T>::apply(v.template get_unchecked<T>()));
         }
         else
         {
@@ -325,12 +325,12 @@ struct dispatcher<F, V, R, T>
 {
     VARIANT_INLINE static R apply_const(V const& v, F&& f)
     {
-        return f(unwrapper<T>::apply_const(v.template get<T>()));
+        return f(unwrapper<T>::apply_const(v.template get_unchecked<T>()));
     }
 
     VARIANT_INLINE static R apply(V& v, F&& f)
     {
-        return f(unwrapper<T>::apply(v.template get<T>()));
+        return f(unwrapper<T>::apply(v.template get_unchecked<T>()));
     }
 };
 
@@ -344,8 +344,8 @@ struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
     {
         if (rhs.template is<T1>()) // call binary functor
         {
-            return f(unwrapper<T0>::apply_const(lhs.template get<T0>()),
-                     unwrapper<T1>::apply_const(rhs.template get<T1>()));
+            return f(unwrapper<T0>::apply_const(lhs.template get_unchecked<T0>()),
+                     unwrapper<T1>::apply_const(rhs.template get_unchecked<T1>()));
         }
         else
         {
@@ -357,8 +357,8 @@ struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
     {
         if (rhs.template is<T1>()) // call binary functor
         {
-            return f(unwrapper<T0>::apply(lhs.template get<T0>()),
-                     unwrapper<T1>::apply(rhs.template get<T1>()));
+            return f(unwrapper<T0>::apply(lhs.template get_unchecked<T0>()),
+                     unwrapper<T1>::apply(rhs.template get_unchecked<T1>()));
         }
         else
         {
@@ -372,14 +372,14 @@ struct binary_dispatcher_rhs<F, V, R, T0, T1>
 {
     VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F&& f)
     {
-        return f(unwrapper<T0>::apply_const(lhs.template get<T0>()),
-                 unwrapper<T1>::apply_const(rhs.template get<T1>()));
+        return f(unwrapper<T0>::apply_const(lhs.template get_unchecked<T0>()),
+                 unwrapper<T1>::apply_const(rhs.template get_unchecked<T1>()));
     }
 
     VARIANT_INLINE static R apply(V& lhs, V& rhs, F&& f)
     {
-        return f(unwrapper<T0>::apply(lhs.template get<T0>()),
-                 unwrapper<T1>::apply(rhs.template get<T1>()));
+        return f(unwrapper<T0>::apply(lhs.template get_unchecked<T0>()),
+                 unwrapper<T1>::apply(rhs.template get_unchecked<T1>()));
     }
 };
 
@@ -393,8 +393,8 @@ struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
     {
         if (lhs.template is<T1>()) // call binary functor
         {
-            return f(unwrapper<T1>::apply_const(lhs.template get<T1>()),
-                     unwrapper<T0>::apply_const(rhs.template get<T0>()));
+            return f(unwrapper<T1>::apply_const(lhs.template get_unchecked<T1>()),
+                     unwrapper<T0>::apply_const(rhs.template get_unchecked<T0>()));
         }
         else
         {
@@ -406,8 +406,8 @@ struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
     {
         if (lhs.template is<T1>()) // call binary functor
         {
-            return f(unwrapper<T1>::apply(lhs.template get<T1>()),
-                     unwrapper<T0>::apply(rhs.template get<T0>()));
+            return f(unwrapper<T1>::apply(lhs.template get_unchecked<T1>()),
+                     unwrapper<T0>::apply(rhs.template get_unchecked<T0>()));
         }
         else
         {
@@ -421,14 +421,14 @@ struct binary_dispatcher_lhs<F, V, R, T0, T1>
 {
     VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F&& f)
     {
-        return f(unwrapper<T1>::apply_const(lhs.template get<T1>()),
-                 unwrapper<T0>::apply_const(rhs.template get<T0>()));
+        return f(unwrapper<T1>::apply_const(lhs.template get_unchecked<T1>()),
+                 unwrapper<T0>::apply_const(rhs.template get_unchecked<T0>()));
     }
 
     VARIANT_INLINE static R apply(V& lhs, V& rhs, F&& f)
     {
-        return f(unwrapper<T1>::apply(lhs.template get<T1>()),
-                 unwrapper<T0>::apply(rhs.template get<T0>()));
+        return f(unwrapper<T1>::apply(lhs.template get_unchecked<T1>()),
+                 unwrapper<T0>::apply(rhs.template get_unchecked<T0>()));
     }
 };
 
@@ -444,8 +444,8 @@ struct binary_dispatcher<F, V, R, T, Types...>
         {
             if (v1.template is<T>())
             {
-                return f(unwrapper<T>::apply_const(v0.template get<T>()),
-                         unwrapper<T>::apply_const(v1.template get<T>())); // call binary functor
+                return f(unwrapper<T>::apply_const(v0.template get_unchecked<T>()),
+                         unwrapper<T>::apply_const(v1.template get_unchecked<T>())); // call binary functor
             }
             else
             {
@@ -465,8 +465,8 @@ struct binary_dispatcher<F, V, R, T, Types...>
         {
             if (v1.template is<T>())
             {
-                return f(unwrapper<T>::apply(v0.template get<T>()),
-                         unwrapper<T>::apply(v1.template get<T>())); // call binary functor
+                return f(unwrapper<T>::apply(v0.template get_unchecked<T>()),
+                         unwrapper<T>::apply(v1.template get_unchecked<T>())); // call binary functor
             }
             else
             {
@@ -486,14 +486,14 @@ struct binary_dispatcher<F, V, R, T>
 {
     VARIANT_INLINE static R apply_const(V const& v0, V const& v1, F&& f)
     {
-        return f(unwrapper<T>::apply_const(v0.template get<T>()),
-                 unwrapper<T>::apply_const(v1.template get<T>())); // call binary functor
+        return f(unwrapper<T>::apply_const(v0.template get_unchecked<T>()),
+                 unwrapper<T>::apply_const(v1.template get_unchecked<T>())); // call binary functor
     }
 
     VARIANT_INLINE static R apply(V& v0, V& v1, F&& f)
     {
-        return f(unwrapper<T>::apply(v0.template get<T>()),
-                 unwrapper<T>::apply(v1.template get<T>())); // call binary functor
+        return f(unwrapper<T>::apply(v0.template get_unchecked<T>()),
+                 unwrapper<T>::apply(v1.template get_unchecked<T>())); // call binary functor
     }
 };
 
@@ -527,7 +527,7 @@ class comparer
     template <typename T>
     bool operator()(T const& rhs_content) const
     {
-        T const& lhs_content = lhs_.template get<T>();
+        T const& lhs_content = lhs_.template get_unchecked<T>();
         return Comp()(lhs_content, rhs_content);
     }
 
@@ -681,6 +681,15 @@ class variant
         type_index = detail::direct_type<T, Types...>::index;
     }
 
+    // get_unchecked<T>()
+    template <typename T, typename std::enable_if<
+                              (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
+    VARIANT_INLINE T& get_unchecked()
+    {
+        return *reinterpret_cast<T*>(&data);
+    }
+
+#ifdef __EXCEPTIONS
     // get<T>()
     template <typename T, typename std::enable_if<
                               (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
@@ -695,7 +704,16 @@ class variant
             throw bad_variant_access("in get<T>()");
         }
     }
+#endif
 
+    template <typename T, typename std::enable_if<
+                              (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
+    VARIANT_INLINE T const& get_unchecked() const
+    {
+        return *reinterpret_cast<T const*>(&data);
+    }
+
+#ifdef __EXCEPTIONS
     template <typename T, typename std::enable_if<
                               (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
     VARIANT_INLINE T const& get() const
@@ -709,7 +727,17 @@ class variant
             throw bad_variant_access("in get<T>()");
         }
     }
+#endif
 
+    // get_unchecked<T>() - T stored as recursive_wrapper<T>
+    template <typename T, typename std::enable_if<
+                              (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
+    VARIANT_INLINE T& get_unchecked()
+    {
+        return (*reinterpret_cast<recursive_wrapper<T>*>(&data)).get();
+    }
+
+#ifdef __EXCEPTIONS
     // get<T>() - T stored as recursive_wrapper<T>
     template <typename T, typename std::enable_if<
                               (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
@@ -724,7 +752,16 @@ class variant
             throw bad_variant_access("in get<T>()");
         }
     }
+#endif
 
+    template <typename T, typename std::enable_if<
+                              (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
+    VARIANT_INLINE T const& get_unchecked() const
+    {
+        return (*reinterpret_cast<recursive_wrapper<T> const*>(&data)).get();
+    }
+
+#ifdef __EXCEPTIONS
     template <typename T, typename std::enable_if<
                               (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
     VARIANT_INLINE T const& get() const
@@ -738,7 +775,17 @@ class variant
             throw bad_variant_access("in get<T>()");
         }
     }
+#endif
 
+    // get_unchecked<T>() - T stored as std::reference_wrapper<T>
+    template <typename T, typename std::enable_if<
+                              (detail::direct_type<std::reference_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
+    VARIANT_INLINE T& get_unchecked()
+    {
+        return (*reinterpret_cast<std::reference_wrapper<T>*>(&data)).get();
+    }
+
+#ifdef __EXCEPTIONS
     // get<T>() - T stored as std::reference_wrapper<T>
     template <typename T, typename std::enable_if<
                               (detail::direct_type<std::reference_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
@@ -753,7 +800,16 @@ class variant
             throw bad_variant_access("in get<T>()");
         }
     }
+#endif
 
+    template <typename T, typename std::enable_if<
+                              (detail::direct_type<std::reference_wrapper<T const>, Types...>::index != detail::invalid_value)>::type* = nullptr>
+    VARIANT_INLINE T const& get_unchecked() const
+    {
+        return (*reinterpret_cast<std::reference_wrapper<T const> const*>(&data)).get();
+    }
+
+#ifdef __EXCEPTIONS
     template <typename T, typename std::enable_if<
                               (detail::direct_type<std::reference_wrapper<T const>, Types...>::index != detail::invalid_value)>::type* = nullptr>
     VARIANT_INLINE T const& get() const
@@ -767,6 +823,7 @@ class variant
             throw bad_variant_access("in get<T>()");
         }
     }
+#endif
 
     // This function is deprecated because it returns an internal index field.
     // Use which() instead.
@@ -891,16 +948,33 @@ auto VARIANT_INLINE apply_visitor(F&& f, V& v0, V& v1) -> decltype(V::binary_vis
 }
 
 // getter interface
+
+#ifdef __EXCEPTIONS
 template <typename ResultType, typename T>
 ResultType& get(T& var)
 {
     return var.template get<ResultType>();
 }
+#endif
 
+template <typename ResultType, typename T>
+ResultType& get_unchecked(T& var)
+{
+    return var.template get_unchecked<ResultType>();
+}
+
+#ifdef __EXCEPTIONS
 template <typename ResultType, typename T>
 ResultType const& get(T const& var)
 {
     return var.template get<ResultType>();
+}
+#endif
+
+template <typename ResultType, typename T>
+ResultType const& get_unchecked(T const& var)
+{
+    return var.template get_unchecked<ResultType>();
 }
 } // namespace util
 } // namespace mapbox


### PR DESCRIPTION
Currently, all calls to `get<type>()` check that the current type is the specified type and throw an exception if they aren't. When using `.is<type>()` to check before, this check isn't necessary and prevents usage of variant when exceptions are disabled.