### PR TITLE
Add static constexpr which<T>() to obtain type ids

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -780,6 +780,13 @@ class variant
         return static_cast<int>(sizeof...(Types)-type_index - 1);
     }
 
+    template <typename T, typename std::enable_if<
+                              (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
+    VARIANT_INLINE static constexpr int which() noexcept
+    {
+        return static_cast<int>(sizeof...(Types)-detail::direct_type<T, Types...>::index - 1);
+    }
+
     // visitor
     // unary
     template <typename F, typename V, typename R = typename detail::result_of_unary_visit<F, first_type>::type>


### PR DESCRIPTION
The result of `which()` is an integer, but there's no constexpr way to get a certain types which value.