### PR TITLE
Useful traits and Boost.Spirit Qi/Karma support headers for mapbox::variant.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS := $(LDFLAGS)
 
 ALL_HEADERS = $(shell find include/mapbox/ '(' -name '*.hpp' ')')
 
-all: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
+all: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test out/boost_spirit_karma out/boost_spirit_qi
 
 mason_packages:
 	git submodule update --init .mason
@@ -46,6 +46,14 @@ out/recursive_wrapper_test: Makefile mason_packages test/recursive_wrapper_test.
 out/binary_visitor_test: Makefile mason_packages test/binary_visitor_test.cpp
 	mkdir -p ./out
 	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+
+out/boost_spirit_qi:
+	mkdir -p ./out
+	$(CXX) -o out/boost_spirit_qi test/boost_spirit_qi.cpp -I./include -Itest/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+
+out/boost_spirit_karma:
+	mkdir -p ./out
+	$(CXX) -o out/boost_spirit_karma test/boost_spirit_karma.cpp -I./include -Itest/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
 	./out/bench-variant 100000

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Tested with:
 There is nothing to build, just include `variant.hpp` in your project. Include `variant_io.hpp` if you need
 the `operator<<` overload for variant.
 
+### Usage with Boost.Spirit
+If you want to use MapBox.Variant with the [Boost.Spirit](http://www.boost.org/doc/libs/release/libs/spirit/doc/html/index.html) library, you can simply use the following supporting headers : 
+
+  * `#include <mapbox/boost_spirit_qi.hpp>`
+  * `#include <mapbox/boost_spirit_karma.hpp>`
+
+Examples are available here : [Boost.Spirit.Qi](test/boost_spirit_qi.cpp), [Boost.Spirit.Karma](test/boost_spirit_karma.cpp).
 
 ## Unit Tests
 

--- a/include/mapbox/boost_spirit_karma.hpp
+++ b/include/mapbox/boost_spirit_karma.hpp
@@ -1,0 +1,14 @@
+// Copyright 2016 Damien Buhl (alias daminetreg) for Fr. Sauter AG, CH-4016 BASEL
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+#ifndef MAPBOX_BOOST_SPIRIT_KARMA_HPP
+#define MAPBOX_BOOST_SPIRIT_KARMA_HPP
+
+#include <mapbox/variant.hpp>
+
+namespace boost { using mapbox::util::get; }
+
+#include <mapbox/detail/boost_spirit_attributes.hpp>
+
+#endif

--- a/include/mapbox/boost_spirit_qi.hpp
+++ b/include/mapbox/boost_spirit_qi.hpp
@@ -1,0 +1,25 @@
+// Copyright 2016 Damien Buhl (alias daminetreg) for Fr. Sauter AG, CH-4016 BASEL
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+#ifndef MAPBOX_BOOST_SPIRIT_QI_HPP
+#define MAPBOX_BOOST_SPIRIT_QI_HPP
+
+#include <mapbox/detail/boost_spirit_attributes.hpp>
+
+#include <boost/spirit/include/qi_alternative.hpp>
+
+namespace boost { namespace spirit { namespace qi { namespace detail
+{
+    template <typename Expected, class... Types>
+    struct find_substitute<mapbox::util::variant<Types...>, Expected>
+    {
+        // Get the typr from the variant that can be a substitute for Expected.
+        // If none is found, just return Expected
+
+        typedef Expected type;
+    };
+}}}}
+
+
+#endif

--- a/include/mapbox/detail/boost_spirit_attributes.hpp
+++ b/include/mapbox/detail/boost_spirit_attributes.hpp
@@ -1,0 +1,67 @@
+// Copyright 2016 Damien Buhl (alias daminetreg) for Fr. Sauter AG, CH-4016 BASEL
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+#ifndef MAPBOX_DETAIL_BOOST_SPIRIT_ATTRIBUTES_HPP
+#define MAPBOX_DETAIL_BOOST_SPIRIT_ATTRIBUTES_HPP
+
+#include <mapbox/variant.hpp>
+
+#include <mapbox/traits/is_mapbox_variant.hpp>
+#include <mapbox/traits/is_type_in_variant.hpp>
+
+#include <boost/spirit/home/support/attributes.hpp>
+
+// Defines the trait for Boost.Spirit to treat mapbox::util::variant as a variant.
+namespace boost { namespace spirit { namespace traits
+{
+    template <typename Domain, class... Types>
+    struct not_is_variant<mapbox::util::variant<Types...>, Domain>
+      : mpl::false_
+    {};
+}
+}}
+
+namespace boost { namespace spirit { namespace traits {
+
+    template <class... Types>
+    struct variant_which< mapbox::util::variant<Types...> >
+    {
+        static int call(mapbox::util::variant<Types...> const& v)
+        {
+            return v.which();
+        }
+    };
+
+}}}
+
+namespace boost { namespace spirit { namespace traits {
+
+    template <typename Variant, typename Expected>
+    struct compute_compatible_component_variant<Variant, Expected, mpl::false_
+      , typename enable_if< typename mapbox::traits::is_mapbox_variant<Variant>::type >::type>
+    {
+        typedef typename traits::variant_type<Variant>::type variant_type;
+
+        // true_ if the attribute matches one of the types in the variant
+        typedef mapbox::traits::is_type_in_variant<Expected, Variant> type;
+        enum { value = type::value };
+
+        // return the type in the variant the attribute is compatible with
+        typedef typename
+            mpl::eval_if<type, mpl::identity<Expected>, mpl::identity<unused_type> >::type
+        compatible_type;
+
+        // return whether the given type is compatible with the Expected type
+        static bool is_compatible(int which)
+        {
+          auto idx = (type::size - 1 - type::index); // Typelist is inverted and 0-based
+          return which == idx;
+        }
+    };
+
+
+}}}
+
+
+#endif

--- a/include/mapbox/traits/is_mapbox_variant.hpp
+++ b/include/mapbox/traits/is_mapbox_variant.hpp
@@ -1,0 +1,33 @@
+// Copyright 2016 Damien Buhl (alias daminetreg) for Fr. Sauter AG, CH-4016 BASEL
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+#ifndef MAPBOX_TRAITS_IS_MAPBOX_VARIANT_HPP
+#define MAPBOX_TRAITS_IS_MAPBOX_VARIANT_HPP
+
+#include <mapbox/variant.hpp>
+
+namespace mapbox { namespace traits { 
+
+  template <class... Types>
+  struct is_mapbox_variant {
+    using type = std::false_type;
+    enum { value = false };
+  };
+
+  template <class... Types>
+  struct is_mapbox_variant<mapbox::util::variant<Types...>> {
+    using type = std::true_type;
+    enum { value = true };
+  };
+
+  template <class... Types>
+  struct is_mapbox_variant<const mapbox::util::variant<Types...>> {
+    using type = std::true_type;
+    enum { value = true };
+  };
+
+
+}}
+
+#endif

--- a/include/mapbox/traits/is_type_in_variant.hpp
+++ b/include/mapbox/traits/is_type_in_variant.hpp
@@ -1,0 +1,30 @@
+// Copyright 2016 Damien Buhl (alias daminetreg) for Fr. Sauter AG, CH-4016 BASEL
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+#ifndef MAPBOX_TRAITS_IS_TYPE_IN_VARIANT_HPP
+#define MAPBOX_TRAITS_IS_TYPE_IN_VARIANT_HPP
+
+#include <mapbox/variant.hpp>
+
+namespace mapbox { namespace traits { 
+
+  template <class T, class... Types>
+  struct is_type_in_variant;
+
+  template <class T, class... Types>
+  struct is_type_in_variant<T, mapbox::util::variant<Types...>> {
+
+    using variant = mapbox::util::variant<Types...>;
+    using direct_type = mapbox::util::detail::direct_type<T, Types...>;
+
+    using type = std::integral_constant<bool, (direct_type::index !=  mapbox::util::detail::invalid_value)>;
+    enum { value = type::value };
+
+    enum { index = direct_type::index };
+    enum { size = sizeof...(Types) };
+  };
+
+}}
+
+#endif

--- a/test/boost_spirit_karma.cpp
+++ b/test/boost_spirit_karma.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <cassert>
+
+#include <mapbox/variant.hpp>
+#include <mapbox/boost_spirit_karma.hpp>
+#include <boost/spirit/include/karma.hpp>
+
+typedef mapbox::util::variant<int, bool, std::string, float, long, uint64_t> frame;
+
+int main() {
+  typedef std::back_insert_iterator<std::string> Iterator;
+
+  using namespace boost::spirit::karma;
+
+  rule<Iterator, std::string()> mystring = *char_;
+
+  rule<Iterator, frame()> r = 
+      int_
+    | bool_
+    | mystring
+  ;
+
+
+  {
+    frame frm = 12;
+    std::string buf;
+    Iterator iter(buf);
+    auto s = generate(iter, r, frm); 
+
+    std::cout << (s ? " success " : " error ") << " - " << mapbox::util::get<int>(frm) << " == " << buf << std::endl;
+    assert(s);
+    assert("12" == buf);
+  }
+
+  {
+    frame frm = true;
+    std::string buf;
+    Iterator iter(buf);
+    auto s = generate(iter, r, frm); 
+
+    std::cout << (s ? " success " : " error ") << " - " << mapbox::util::get<bool>(frm) << " == " << buf << std::endl;
+    assert(s);
+    assert("true" == buf);
+  }
+
+  {
+    frame frm = std::string{"this is a string"};
+    std::string buf;
+    Iterator iter(buf);
+    auto s = generate(iter, r, frm); 
+
+    std::cout << (s ? " success " : " error ") << " - " << mapbox::util::get<std::string>(frm) << " == " << buf << std::endl;
+    assert(s);
+    assert("this is a string" == buf);
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/test/boost_spirit_qi.cpp
+++ b/test/boost_spirit_qi.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <typeinfo>
+#include <cassert>
+
+#include <mapbox/variant.hpp>
+#include <mapbox/boost_spirit_qi.hpp>
+#include <boost/spirit/include/qi.hpp>
+
+typedef mapbox::util::variant<int, bool, std::string> frame;
+
+struct parse_asserter {
+
+  frame _expected;
+  parse_asserter(frame expected) 
+    : _expected(expected) {}
+
+  template <typename T>
+  void operator()(T const& val) const
+  {
+    std::cout << typeid(T).name() << " " << val << std::endl;
+    assert(mapbox::util::get<T>(_expected) == val);
+  }
+
+};
+
+int main() {
+  typedef std::string::const_iterator Iterator;
+
+  using namespace boost::spirit::qi;
+
+  rule<Iterator, frame()> r = 
+      int_
+    | bool_
+    | as_string[*char_]
+  ;
+
+  {
+    frame frm{};
+    const std::string text = "this is a string";
+
+    assert( parse(text.cbegin(), text.cend(), r, frm)  );
+    mapbox::util::apply_visitor(parse_asserter{text}, frm);
+  }
+
+  {
+    frame frm{};
+    const std::string text = "42";
+
+    assert( parse(text.cbegin(), text.cend(), r, frm) );
+    mapbox::util::apply_visitor(parse_asserter{42}, frm);
+  }
+
+  {
+    frame frm{};
+    const std::string text = "true";
+
+    assert( parse(text.cbegin(), text.cend(), r, frm) );
+    mapbox::util::apply_visitor(parse_asserter{true}, frm);
+  }
+
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Dear Mapbox Variant authors,

I would like to contribute support headers for Boost.Spirit.Qi and Karma to mapbox::variant, so that usage of Mapbox::variant with Qi and Karma get really easy. 

## Why ?
  - Currently if you have a really large variant type (e.g. more as 50) with Boost.Spirit you need to re-preprocess the Boost.Mpl headers to enable your type to be compiled with Boost.Variant.
  - Meaning you need a Patched Boost. With all the problems it brings when you are a lib publisher.
  - Bigger mpl::vector<> for a bigger Boost.Variant makes the compile times of qi::rule and karma::rule decrease significantly.
  - It also has strong impact on binary sizes, that with MapBox::Variant gets away. :smile:

| small test program with                   | Boost.Variant | MapBox.Variant |
|--------------------|---------------|----------------|
| Boost.Spirit Qi    | 75 Kb         | 63 Kb          |
| Boost.Spirit Karma | 119 Kb        | 83 Kb          |
[See benchmark code here](https://github.com/sauter-hq/boost-spirit-mapbox-variant)

So I updated a big codebase which was using Boost.Variant and Boost.Spirit together with Mapbox::variant. And now it compiles faster, makes smaller binaries and we don't need a patched Boost MPL anymore ! :grinning: Thank you very much for this variant type.

## Features
The small supporting headers I wrote might be useful for users of this library, therefore I would like to contribute the following to Mapbox::Variant : 

  1. [A metafunction](https://github.com/sauter-hq/variant/blob/8c0cc0315d0d6fbb102d1bbcbf355ded1334e5fe/include/mapbox/traits/is_mapbox_variant.hpp) to detect whether some type is a mapbox::variant
  2. [A metafunction](https://github.com/sauter-hq/variant/blob/8c0cc0315d0d6fbb102d1bbcbf355ded1334e5fe/include/mapbox/traits/is_type_in_variant.hpp) to check if a type is part of a variant.
  3. One supporting header for Boost.Spirit.Qi, defining the required traits
  4. One supporting header for Boost.Spirit.Karma,  defining the required traits.

I would naturally understand that the supporting header for Qi and Karma are not interesting you as part of the library, as they base on the Boost.Spirit traits which are documented only in spirit code but which are used extensively internally by the library and provided as supporting headers since ages (https://github.com/boostorg/spirit/blob/develop/include/boost/spirit/home/support/extended_variant.hpp).

Following if you are interested in the supporting headers for Boost.Spirit or not I will publish them as a separate library and remove 3. and 4. from this PR. 

But I really would love to see the `include/mapbox/traits/is_mapbox_variant.hpp` and ` include/mapbox/traits/is_type_in_variant.hpp` accepted, as they are in my opinion features that should be part of Mapbox Variant.

You can test out the supporting headers by running : 
 - `make out/boost_spirit_karma && out/boost_spirit_karma`
 - `make out/boost_spirit_qi && out/boost_spirit_karma`

Cheers