### PR TITLE
Provides Convenient Lambda Overload Visitor Interface, resolves #113.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS := $(LDFLAGS)
 
 ALL_HEADERS = $(shell find include/mapbox/ '(' -name '*.hpp' ')')
 
-all: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
+all: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test out/lambda_overload_test
 
 mason_packages:
 	git submodule update --init .mason
@@ -46,6 +46,10 @@ out/recursive_wrapper_test: Makefile mason_packages test/recursive_wrapper_test.
 out/binary_visitor_test: Makefile mason_packages test/binary_visitor_test.cpp
 	mkdir -p ./out
 	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+
+out/lambda_overload_test: Makefile mason_packages test/lambda_overload_test.cpp
+	mkdir -p ./out
+	$(CXX) -o out/lambda_overload_test test/lambda_overload_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
 	./out/bench-variant 100000

--- a/include/mapbox/variant_visitor.hpp
+++ b/include/mapbox/variant_visitor.hpp
@@ -1,0 +1,40 @@
+#ifndef MAPBOX_UTIL_VARIANT_VISITOR_HPP
+#define MAPBOX_UTIL_VARIANT_VISITOR_HPP
+
+namespace mapbox {
+namespace util {
+
+template <typename... Fns>
+struct visitor;
+
+template <typename Fn>
+struct visitor<Fn> : Fn
+{
+    using type = Fn;
+
+    using Fn::operator();
+
+    visitor(Fn fn) : Fn(fn) {}
+};
+
+template <typename Fn, typename... Fns>
+struct visitor<Fn, Fns...> : Fn, visitor<Fns...>::type
+{
+    using type = visitor;
+
+    using Fn::operator();
+    using visitor<Fns...>::type::operator();
+
+    visitor(Fn fn, Fns... fns) : Fn(fn), visitor<Fns...>::type(fns...) {}
+};
+
+template <typename... Fns>
+typename visitor<Fns...>::type make_visitor(Fns... fns)
+{
+    return visitor<Fns...>(fns...);
+}
+
+} // namespace util
+} // namespace mapbox
+
+#endif // MAPBOX_UTIL_VARIANT_VISITOR_HPP

--- a/include/mapbox/variant_visitor.hpp
+++ b/include/mapbox/variant_visitor.hpp
@@ -10,26 +10,22 @@ struct visitor;
 template <typename Fn>
 struct visitor<Fn> : Fn
 {
-    using type = Fn;
-
     using Fn::operator();
 
     visitor(Fn fn) : Fn(fn) {}
 };
 
 template <typename Fn, typename... Fns>
-struct visitor<Fn, Fns...> : Fn, visitor<Fns...>::type
+struct visitor<Fn, Fns...> : Fn, visitor<Fns...>
 {
-    using type = visitor;
-
     using Fn::operator();
-    using visitor<Fns...>::type::operator();
+    using visitor<Fns...>::operator();
 
-    visitor(Fn fn, Fns... fns) : Fn(fn), visitor<Fns...>::type(fns...) {}
+    visitor(Fn fn, Fns... fns) : Fn(fn), visitor<Fns...>(fns...) {}
 };
 
 template <typename... Fns>
-typename visitor<Fns...>::type make_visitor(Fns... fns)
+visitor<Fns...> make_visitor(Fns... fns)
 {
     return visitor<Fns...>(fns...);
 }

--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+
+#include <mapbox/variant.hpp>
+#include <mapbox/variant_visitor.hpp>
+
+using namespace mapbox::util;
+
+template <typename Left, typename Right>
+using Either = mapbox::util::variant<Left, Right>;
+
+struct Response
+{
+};
+
+struct Error
+{
+};
+
+void test_lambda_overloads()
+{
+    Either<Error, Response> rv;
+
+    rv = Response{};
+
+    auto visitor = make_visitor([](Response) { std::cout << "Response\n"; }, //
+                                [](Error) { std::cout << "Error\n"; });      //
+    apply_visitor(visitor, rv);
+}
+
+void test_lambda_overloads_capture()
+{
+    Either<Error, Response> rv;
+
+    rv = Error{};
+
+    int ok = 0;
+    int err = 0;
+
+    auto visitor = make_visitor([&](Response) { ok += 1; }, //
+                                [&](Error) { err += 1; });  //
+    apply_visitor(visitor, rv);
+
+    std::cout << "Got " << ok << " ok, " << err << " err" << std::endl;
+}
+
+void test_singleton_variant()
+{
+
+    variant<int> singleton;
+    apply_visitor(make_visitor([](int) {}), singleton);
+}
+
+int main()
+{
+    test_lambda_overloads();
+    test_singleton_variant();
+    test_lambda_overloads_capture();
+}

--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -1,7 +1,12 @@
 #include <iostream>
+#include <vector>
 
 #include <mapbox/variant.hpp>
 #include <mapbox/variant_visitor.hpp>
+
+#if __cplusplus >= 201402L
+#define HAS_CPP14_SUPPORT
+#endif
 
 using namespace mapbox::util;
 
@@ -50,9 +55,38 @@ void test_singleton_variant()
     apply_visitor(make_visitor([](int) {}), singleton);
 }
 
+#ifdef HAS_CPP14_SUPPORT
+void test_lambda_overloads_sfinae()
+{
+    variant<int, float, std::vector<int>> var;
+
+    auto visitor = make_visitor([](auto range) -> decltype(std::begin(range), void()) {
+                                    for (auto each : range)
+                                        std::cout << each << ' '; },
+                                [](auto x) -> decltype(std::cout << x, void()) {
+                                    std::cout << x << std::endl;
+                                });
+
+    var = 1;
+    apply_visitor(visitor, var);
+
+    var = 2.f;
+    apply_visitor(visitor, var);
+
+    var = std::vector<int>{4, 5, 6};
+    apply_visitor(visitor, var);
+}
+#endif
+
 int main()
 {
     test_lambda_overloads();
     test_singleton_variant();
     test_lambda_overloads_capture();
+
+#ifdef HAS_CPP14_SUPPORT
+    test_lambda_overloads_sfinae();
+#endif
 }
+
+#undef HAS_CPP14_SUPPORT


### PR DESCRIPTION
See https://github.com/mapbox/variant/issues/113 for details.

This provides a `make_visitor` function taking lambdas and creating a
visitor functor out of it.

There are three points to conder here:

1/ Eventually we want to provide a convenient member function
so that we can plug in lambda overloads directly as in:

```c++
variant.match([] (Response) { return "ok"; },
              [] (Error)    { return "error"; });
```

at the moment we still have to:

```c++
auto visitor = make_visitor([] (Response) { return "ok"; },
                            [] (Error)    { return "error"; });
apply_visitor(visitor, variant);
```

2/ At the moment we copy the lambdas. This is fine and follows the
stdlib but we could take them as forwarding reference instead.

3/ Maybe we should consider edge cases, such as member function pointers
and provide specializations accordingly. The primary use-case is lambdas,
though.