### PR TITLE
Pattern Matching for Sum Types via `.match` Member Function

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include <mapbox/recursive_wrapper.hpp>
+#include <mapbox/variant_visitor.hpp>
 
 // clang-format off
 // [[deprecated]] is only available in C++14, use this for the time being
@@ -859,6 +860,22 @@ public:
         -> decltype(detail::binary_dispatcher<F, V, R, Types...>::apply(v0, v1, std::forward<F>(f)))
     {
         return detail::binary_dispatcher<F, V, R, Types...>::apply(v0, v1, std::forward<F>(f));
+    }
+
+    // match
+    // unary
+    template <typename... Fs>
+    auto VARIANT_INLINE match(Fs&&... fs) const
+        -> decltype(variant::visit(*this, ::mapbox::util::make_visitor(std::forward<Fs>(fs)...)))
+    {
+        return variant::visit(*this, ::mapbox::util::make_visitor(std::forward<Fs>(fs)...));
+    }
+    // non-const
+    template <typename... Fs>
+    auto VARIANT_INLINE match(Fs&&... fs)
+        -> decltype(variant::visit(*this, ::mapbox::util::make_visitor(std::forward<Fs>(fs)...)))
+    {
+        return variant::visit(*this, ::mapbox::util::make_visitor(std::forward<Fs>(fs)...));
     }
 
     ~variant() noexcept // no-throw destructor

--- a/include/mapbox/variant_visitor.hpp
+++ b/include/mapbox/variant_visitor.hpp
@@ -10,6 +10,7 @@ struct visitor;
 template <typename Fn>
 struct visitor<Fn> : Fn
 {
+    using type = Fn;
     using Fn::operator();
 
     visitor(Fn fn) : Fn(fn) {}
@@ -18,6 +19,7 @@ struct visitor<Fn> : Fn
 template <typename Fn, typename... Fns>
 struct visitor<Fn, Fns...> : Fn, visitor<Fns...>
 {
+    using type = visitor;
     using Fn::operator();
     using visitor<Fns...>::operator();
 

--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -55,8 +55,8 @@ void test_singleton_variant()
     apply_visitor(make_visitor([](int) {}), singleton);
 }
 
-#ifdef HAS_CPP14_SUPPORT
 void test_lambda_overloads_sfinae()
+#ifdef HAS_CPP14_SUPPORT
 {
     variant<int, float, std::vector<int>> var;
 
@@ -76,17 +76,52 @@ void test_lambda_overloads_sfinae()
     var = std::vector<int>{4, 5, 6};
     apply_visitor(visitor, var);
 }
+#else
+{
+}
 #endif
+
+void test_match_singleton()
+{
+    variant<int> singleton = 5;
+    singleton.match([](int) {});
+}
+
+void test_match_overloads()
+{
+    Either<Error, Response> rv;
+
+    rv = Response{};
+
+    rv.match([](Response) { std::cout << "Response\n"; }, //
+             [](Error) { std::cout << "Error\n"; });      //
+}
+
+void test_match_overloads_capture()
+{
+    Either<Error, Response> rv;
+
+    rv = Error{};
+
+    int ok = 0;
+    int err = 0;
+
+    rv.match([&](Response) { ok += 1; }, //
+             [&](Error) { err += 1; });  //
+
+    std::cout << "Got " << ok << " ok, " << err << " err" << std::endl;
+}
 
 int main()
 {
     test_lambda_overloads();
     test_singleton_variant();
     test_lambda_overloads_capture();
-
-#ifdef HAS_CPP14_SUPPORT
     test_lambda_overloads_sfinae();
-#endif
+
+    test_match_singleton();
+    test_match_overloads();
+    test_match_overloads_capture();
 }
 
 #undef HAS_CPP14_SUPPORT


### PR DESCRIPTION
Part II based on our lambda overload set https://github.com/mapbox/variant/pull/124.

Member function `.match` for accepting an arbitrary number of lambdas
building a single functor out of the lambdas for visitation.

This mimics pattern matching as known from languages like Haskell,
and works with C++ lambdas for convenience. In fact lambdas are the
primary if not only use-case for this at the moment.

Usage:

```c++
variant<T, U> v;

v.match([](T){ cout << "I'm a T"; },
        [](U){ cout << "I'm a U"; });
```

Note: you can use lambda captures (e.g. `[&](T){ ts += 1; }`) to
interact with the outside easily.

References:
- https://www.haskell.org/definition/haskell2010.pdf 3.17
- https://doc.rust-lang.org/book/enums.html
- https://doc.rust-lang.org/book/match.html
- http://dl.acm.org/citation.cfm?id=2384686
- http://stroustrup.com/OOPSLA-typeswitch-draft.pdf