### PR TITLE
Adds Documentation for Readme, resolves #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,168 @@
 # Mapbox Variant
 
-An alternative to `boost::variant` for C++11 and C++14
+An header-only alternative to `boost::variant` for C++11 and C++14
 
 [![Build Status](https://secure.travis-ci.org/mapbox/variant.svg)](https://travis-ci.org/mapbox/variant)
 [![Build status](https://ci.appveyor.com/api/projects/status/v9tatx21j1k0fcgy)](https://ci.appveyor.com/project/Mapbox/variant)
 [![Coverage Status](https://coveralls.io/repos/mapbox/variant/badge.svg?branch=master&service=github)](https://coveralls.io/r/mapbox/variant?branch=master)
+
+## Introduction
+
+Variant's basic building blocks are:
+- `variant<Ts...>` - a type-safe representation for sum-types / discriminated unions
+- `recursive_wrapper<T>` - a helper type to represent recursive "tree-like" variants
+- `apply_visitor(visitor, myVariant)` - to invoke a custom visitor on the variant's underlying type
+- `get<T>()` - a function to directly unwrap a variant's underlying type
+- `.match([](Type){})` - a variant convenience member function taking an arbitrary number of lambdas creating a visitor behind the scenes and applying it to the variant
+
+
+### Basic Usage - HTTP API Example
+
+Suppose you want to represent a HTTP API response which is either a JSON result or an error:
+
+```c++
+struct Result {
+  Json object;
+};
+
+struct Error {
+  int32_t code;
+  string message;
+};
+```
+
+You can represent this at type level using a variant which is either an `Error` or a `Result`:
+
+```c++
+using Response = variant<Error, Result>;
+
+Response makeRequest() {
+  return Error{501, "Not Implemented"};
+}
+
+Response ret = makeRequest();
+```
+
+To see which type the `Response` holds you pattern match on the variant unwrapping the underlying value:
+
+```c++
+ret.match([] (Result r) { print(r.object); }
+          [] (Error e)  { print(e.message); });
+```
+
+Instead of using the variant's convenience `.match` pattern matching function you can create a type visitor functor and use `apply_visitor` manually:
+
+```c++
+struct ResponseVisitor {
+  void operator()(Result r) const {
+    print(r.object);
+  }
+
+  void operator()(Error e) const {
+    print(e.message);
+  }
+};
+
+ResponseVisitor visitor;
+apply_visitor(visitor, ret);
+```
+
+In both cases the compiler makes sure you handle all types the variant can represent at compile.
+
+
+### Recursive Variants - JSON Example
+
+[JSON](http://www.json.org/) consists of types `String`, `Number`, `True`, `False`, `Null`, `Array` and `Object`.
+
+
+```c++
+struct String { string value; };
+struct Number { double value; };
+struct True   { };
+struct False  { };
+struct Null   { };
+struct Array  { vector<?> values; };
+struct Object { unordered_map<string, ?> values; };
+```
+
+This works for primitive types but how do we represent recursive types such as `Array` which can hold multiple elements and `Array` itself, too?
+
+For these use cases Variant provides a `recursive_wrapper` helper type which lets you express recursive Variants.
+
+```c++
+struct String { string value; };
+struct Number { double value; };
+struct True   { };
+struct False  { };
+struct Null   { };
+
+// Forward declarations only
+struct Array;
+struct Object;
+
+using Value = variant<String, Number, True, False, Null, recursive_wrapper<Array>, recursive_wrapper<Object>>;
+
+struct Array {
+  vector<Value> values;
+};
+
+struct Object {
+  unordered_map<string, Value> values;
+};
+```
+
+For walkig the JSON representation you can again either create a `JSONVisitor`:
+
+```c++
+struct JSONVisitor {
+
+  void operator()(Null) const {
+    print("null");
+  }
+
+  // same for all other JSON types
+};
+
+JSONVisitor visitor;
+apply_visitor(visitor, json);
+```
+
+Or use the convenience `.match` pattern matching function:
+
+```c++
+json.match([] (Null) { print("null"); },
+           ...);
+```
+
+To summarize: use `recursive_wrapper` to represent recursive "tree-like" representations:
+
+```c++
+struct Empty { };
+struct Node;
+
+using Tree = variant<Empty, recursive_wrapper<Node>>;
+
+struct Node {
+  uint64_t value;
+}
+```
+### Advanced Usage Tips
+
+Creating type aliases for variants is a great way to reduce repetition.
+Keep in mind those type aliases are not checked at type level, though.
+We recommend creating a new type for all but basic variant usage:
+
+```c++
+// the compiler can't tell the following two apart
+using APIResult = variant<Error, Result>;
+using FilesystemResult = variant<Error, Result>;
+
+// new type
+struct APIResult : variant<Error, Result> {
+  using Base = variant<Error, Result>;
+  using Base::Base;
+}
+```
 
 
 ## Why use Mapbox Variant?
@@ -45,6 +203,9 @@ implementations](doc/other_implementations.md).
 Want to know more about the upcoming standard? Have a look at our
 [overview](doc/standards_effort.md).
 
+Most modern high-level languages provide ways to express sum types directly.
+If you're curious have a look at Haskell's pattern matching or Rust's and Swift's enums.
+
 
 ## Depends
 
@@ -62,11 +223,6 @@ Tested with:
  - clang++-3.8
  - clang++-3.9
  - Visual Studio 2015
-
-## Usage
-
-There is nothing to build, just include `variant.hpp` in your project. Include `variant_io.hpp` if you need
-the `operator<<` overload for variant.
 
 
 ## Unit Tests


### PR DESCRIPTION
Note: already includes docs for `.match` https://github.com/mapbox/variant/pull/128.

Please have a look: https://github.com/daniel-j-h/variant/blob/docs/README.md#mapbox-variant