### PR TITLE
Starts building with -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
-          packages: [ 'clang-3.5' ]
+          packages: [ 'clang-3.5', 'libstdc++-4.9-dev' ]
     - os: linux
       compiler: "clang36"
       env: CXX=clang++-3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,14 @@ install:
    fi
 
 script:
+ # Build in Release
+ - make test
+ - make bench
+ - make sizes
+ - scripts/run_compilation_failure_tests.sh
+ - make clean;
+ # Build in Debug
+ - export BUILDTYPE=Debug
  - make test
  - make bench
  - make sizes

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ matrix:
           packages: [ 'clang-3.7' ]
     - os: linux
       compiler: "gcc47"
-      env: CXX=g++-4.7
+      env: CXX=g++-4.7 CXXFLAGS="-Wno-parentheses"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ export BUILDTYPE ?= Release
 
 OS := $(shell uname -s)
 ifeq ($(OS), Linux)
-  EXTRA_FLAGS = -pthreads
+  #EXTRA_FLAGS = -pthreads
 endif
 ifeq ($(OS), Darwin)
   EXTRA_FLAGS = -mmacosx-version-min=10.8

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export BUILDTYPE ?= Release
 
 OS := $(shell uname -s)
 ifeq ($(OS), Linux)
-  #EXTRA_FLAGS = -pthreads
+  EXTRA_FLAGS = -pthread
 endif
 ifeq ($(OS), Darwin)
   EXTRA_FLAGS = -mmacosx-version-min=10.8

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,22 @@ BOOST_VERSION = 1.62.0
 CXX := $(CXX)
 CXX_STD ?= c++11
 
-BOOST_FLAGS = -isystem mason_packages/headers/boost/$(BOOST_VERSION)/include/
+BOOST_ROOT = $(shell $(MASON) prefix boost $(BOOST_VERSION))
+BOOST_FLAGS = -isystem $(BOOST_ROOT)/include/
 RELEASE_FLAGS = -O3 -DNDEBUG -march=native -DSINGLE_THREADED -fvisibility-inlines-hidden -fvisibility=hidden
 DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
-COMMON_FLAGS = -Wall -Werror -pedantic -Wextra -Wno-unsequenced -Wsign-compare -Wsign-conversion -Wshadow -Wfloat-conversion -Wunused-parameter -std=$(CXX_STD)
+COMMON_FLAGS = -Wall -Werror -pedantic -Wextra -Wno-unsequenced -Wsign-compare -Wsign-conversion -Wshadow  -Wunused-parameter -std=$(CXX_STD)
 CXXFLAGS := $(CXXFLAGS)
 LDFLAGS := $(LDFLAGS)
+
+export BUILDTYPE ?= Release
+
+ifeq ($(BUILDTYPE),Release)
+	FINAL_CXXFLAGS := $(COMMON_FLAGS) $(RELEASE_FLAGS) $(CXXFLAGS)
+else
+	FINAL_CXXFLAGS := $(COMMON_FLAGS) $(DEBUG_FLAGS) $(CXXFLAGS)
+endif
+
 
 ALL_HEADERS = $(shell find include/mapbox/ '(' -name '*.hpp' ')')
 
@@ -31,31 +41,31 @@ gyp: ./deps/gyp
 
 out/bench-variant-debug: Makefile mason_packages/headers/boost test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -isystem test/include -pthreads $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -isystem test/include -pthreads $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/bench-variant: Makefile mason_packages/headers/boost test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include -isystem test/include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/unique_ptr_test: Makefile mason_packages/headers/boost test/unique_ptr_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include -isystem test/include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/recursive_wrapper_test: Makefile mason_packages/headers/boost test/recursive_wrapper_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include -isystem test/include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/binary_visitor_test: Makefile mason_packages/headers/boost test/binary_visitor_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -isystem test/include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/lambda_overload_test: Makefile mason_packages/headers/boost test/lambda_overload_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/lambda_overload_test test/lambda_overload_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/lambda_overload_test test/lambda_overload_test.cpp -I./include -isystem test/include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/hashable_test: Makefile mason_packages/headers/boost test/hashable_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/hashable_test test/hashable_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/hashable_test test/hashable_test.cpp -I./include -isystem test/include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
 	./out/bench-variant 100000
@@ -65,11 +75,11 @@ bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_w
 
 out/unit.o: Makefile test/unit.cpp
 	mkdir -p ./out
-	$(CXX) -c -o $@ test/unit.cpp -isystem test/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)
+	$(CXX) -c -o $@ test/unit.cpp -isystem test/include $(FINAL_CXXFLAGS)
 
 out/%.o: test/t/%.cpp Makefile $(ALL_HEADERS)
 	mkdir -p ./out
-	$(CXX) -c -o $@ $< -Iinclude -isystem test/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)
+	$(CXX) -c -o $@ $< -Iinclude -isystem test/include $(FINAL_CXXFLAGS)
 
 out/unit: out/unit.o out/binary_visitor_1.o out/binary_visitor_2.o out/binary_visitor_3.o out/binary_visitor_4.o out/binary_visitor_5.o out/binary_visitor_6.o out/issue21.o out/issue122.o out/mutating_visitor.o out/optional.o out/recursive_wrapper.o out/sizeof.o out/unary_visitor.o out/variant.o
 	mkdir -p ./out
@@ -80,14 +90,14 @@ test: out/unit
 
 coverage:
 	mkdir -p ./out
-	$(CXX) -o out/cov-test --coverage test/unit.cpp test/t/*.cpp -I./include -isystem test/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS)
+	$(CXX) -o out/cov-test --coverage test/unit.cpp test/t/*.cpp -I./include -isystem test/include $(FINAL_CXXFLAGS) $(LDFLAGS)
 
 sizes: Makefile
 	mkdir -p ./out
-	@$(CXX) -o ./out/our_variant_hello_world.out include/mapbox/variant.hpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/our_variant_hello_world.out
-	@$(CXX) -o ./out/boost_variant_hello_world.out `$(MASON) prefix boost $(BOOST_VERSION)`/include/boost/variant.hpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world.out
-	@$(CXX) -o ./out/our_variant_hello_world ./test/our_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) &&  du -h ./out/our_variant_hello_world
-	@$(CXX) -o ./out/boost_variant_hello_world ./test/boost_variant_hello_world.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world
+	@$(CXX) -o ./out/our_variant_hello_world.out include/mapbox/variant.hpp -I./include $(FINAL_CXXFLAGS) &&  du -h ./out/our_variant_hello_world.out
+	@$(CXX) -o ./out/boost_variant_hello_world.out $(BOOST_ROOT)/include/boost/variant.hpp -I./include $(FINAL_CXXFLAGS) $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world.out
+	@$(CXX) -o ./out/our_variant_hello_world ./test/our_variant_hello_world.cpp -I./include $(FINAL_CXXFLAGS) &&  du -h ./out/our_variant_hello_world
+	@$(CXX) -o ./out/boost_variant_hello_world ./test/boost_variant_hello_world.cpp -I./include $(FINAL_CXXFLAGS) $(BOOST_FLAGS) &&  du -h ./out/boost_variant_hello_world
 
 profile: out/bench-variant-debug
 	mkdir -p profiling/
@@ -104,8 +114,8 @@ clean:
 	rm -f *.gcda *.gcno
 
 pgo: out Makefile
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -pg -fprofile-generate
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -pg -fprofile-generate
 	./test-variant 500000 >/dev/null 2>/dev/null
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -fprofile-use
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include $(FINAL_CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS) -fprofile-use
 
 .PHONY: sizes test

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,17 @@ CXX_STD ?= c++11
 BOOST_ROOT = $(shell $(MASON) prefix boost $(BOOST_VERSION))
 BOOST_FLAGS = -isystem $(BOOST_ROOT)/include/
 RELEASE_FLAGS = -O3 -DNDEBUG -march=native -DSINGLE_THREADED -fvisibility-inlines-hidden -fvisibility=hidden
-DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer -fstack-protector-strong -fPIE -D_FORTIFY_SOURCE=2 -fwrapv -Wstack-protector -Wformat -Wformat-security -Wpointer-sign
-COMMON_FLAGS = -Wall -Werror -pedantic -Wextra -Wno-unsequenced -Wsign-compare -Wsign-conversion -Wshadow  -Wunused-parameter -std=$(CXX_STD)
+DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer -fPIE -D_FORTIFY_SOURCE=2 -fwrapv -Wstack-protector -Wformat -Wformat-security
+COMMON_FLAGS = -std=$(CXX_STD)
+
+WARNING_FLAGS = -Wall -Werror -pedantic -Wextra -Wsign-compare -Wsign-conversion -Wshadow -Wunused-parameter
+CLANG_WARNING_FLAGS = -Wno-unsequenced -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors
+ifneq (,$(findstring clang,$(CXX)))
+    WARNING_FLAGS += $(CLANG_WARNING_FLAGS)
+endif
+
+COMMON_FLAGS += $(WARNING_FLAGS)
+
 CXXFLAGS := $(CXXFLAGS)
 LDFLAGS := $(LDFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CXX_STD ?= c++11
 BOOST_ROOT = $(shell $(MASON) prefix boost $(BOOST_VERSION))
 BOOST_FLAGS = -isystem $(BOOST_ROOT)/include/
 RELEASE_FLAGS = -O3 -DNDEBUG -march=native -DSINGLE_THREADED -fvisibility-inlines-hidden -fvisibility=hidden
-DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer -fPIE -D_FORTIFY_SOURCE=2 -fwrapv -Wstack-protector -Wformat -Wformat-security
+DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer -fPIE -D_FORTIFY_SOURCE=2 -fwrapv -Wformat -Wformat-security
 COMMON_FLAGS = -std=$(CXX_STD)
 
 WARNING_FLAGS = -Wall -Werror -pedantic -Wextra -Wsign-compare -Wsign-conversion -Wshadow -Wunused-parameter

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ BOOST_VERSION = 1.62.0
 CXX := $(CXX)
 CXX_STD ?= c++11
 
-BOOST_FLAGS = `$(MASON) cflags boost $(BOOST_VERSION)`
+BOOST_FLAGS = -isystem mason_packages/headers/boost/$(BOOST_VERSION)/include/
 RELEASE_FLAGS = -O3 -DNDEBUG -march=native -DSINGLE_THREADED -fvisibility-inlines-hidden -fvisibility=hidden
 DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
-COMMON_FLAGS = -Wall -pedantic -Wextra -Wsign-compare -Wsign-conversion -Wshadow -Wunused-parameter -std=$(CXX_STD)
+COMMON_FLAGS = -Wall -Werror -pedantic -Wextra -Wno-unsequenced -Wsign-compare -Wsign-conversion -Wshadow -Wfloat-conversion -Wunused-parameter -std=$(CXX_STD)
 CXXFLAGS := $(CXXFLAGS)
 LDFLAGS := $(LDFLAGS)
 
@@ -31,31 +31,31 @@ gyp: ./deps/gyp
 
 out/bench-variant-debug: Makefile mason_packages/headers/boost test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -Itest/include -pthreads $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/bench-variant-debug test/bench_variant.cpp -I./include -isystem test/include -pthreads $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/bench-variant: Makefile mason_packages/headers/boost test/bench_variant.cpp
 	mkdir -p ./out
-	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/bench-variant test/bench_variant.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/unique_ptr_test: Makefile mason_packages/headers/boost test/unique_ptr_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/unique_ptr_test test/unique_ptr_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/recursive_wrapper_test: Makefile mason_packages/headers/boost test/recursive_wrapper_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/recursive_wrapper_test test/recursive_wrapper_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/binary_visitor_test: Makefile mason_packages/headers/boost test/binary_visitor_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/binary_visitor_test test/binary_visitor_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/lambda_overload_test: Makefile mason_packages/headers/boost test/lambda_overload_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/lambda_overload_test test/lambda_overload_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/lambda_overload_test test/lambda_overload_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 out/hashable_test: Makefile mason_packages/headers/boost test/hashable_test.cpp
 	mkdir -p ./out
-	$(CXX) -o out/hashable_test test/hashable_test.cpp -I./include -Itest/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
+	$(CXX) -o out/hashable_test test/hashable_test.cpp -I./include -isystem test/include $(RELEASE_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS) $(BOOST_FLAGS)
 
 bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_wrapper_test out/binary_visitor_test
 	./out/bench-variant 100000
@@ -65,11 +65,11 @@ bench: out/bench-variant out/unique_ptr_test out/unique_ptr_test out/recursive_w
 
 out/unit.o: Makefile test/unit.cpp
 	mkdir -p ./out
-	$(CXX) -c -o $@ test/unit.cpp -Itest/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)
+	$(CXX) -c -o $@ test/unit.cpp -isystem test/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)
 
 out/%.o: test/t/%.cpp Makefile $(ALL_HEADERS)
 	mkdir -p ./out
-	$(CXX) -c -o $@ $< -Iinclude -Itest/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)
+	$(CXX) -c -o $@ $< -Iinclude -isystem test/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS)
 
 out/unit: out/unit.o out/binary_visitor_1.o out/binary_visitor_2.o out/binary_visitor_3.o out/binary_visitor_4.o out/binary_visitor_5.o out/binary_visitor_6.o out/issue21.o out/issue122.o out/mutating_visitor.o out/optional.o out/recursive_wrapper.o out/sizeof.o out/unary_visitor.o out/variant.o
 	mkdir -p ./out
@@ -80,7 +80,7 @@ test: out/unit
 
 coverage:
 	mkdir -p ./out
-	$(CXX) -o out/cov-test --coverage test/unit.cpp test/t/*.cpp -I./include -Itest/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS)
+	$(CXX) -o out/cov-test --coverage test/unit.cpp test/t/*.cpp -I./include -isystem test/include $(DEBUG_FLAGS) $(COMMON_FLAGS) $(CXXFLAGS) $(LDFLAGS)
 
 sizes: Makefile
 	mkdir -p ./out

--- a/test/t/binary_visitor_impl.hpp
+++ b/test/t/binary_visitor_impl.hpp
@@ -160,8 +160,8 @@ struct swap_visitor
     {
         using T = typename std::common_type<A, B>::type;
         T tmp = a;
-        a = b;
-        b = tmp;
+        a = static_cast<A>(b);
+        b = static_cast<B>(tmp);
     }
 };
 


### PR DESCRIPTION
This PR adds `-Werror` to the default flags so that builds fail on travis that introduce new and unexpected warnings. It also:

 - Fixes several warnings that were present
 - Starts building in both Release and Debug mode per job (for more coverage)
 - Adds a few more warning flags