### PR TITLE
remove useless and/or dubious compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,11 @@ CXX_STD ?= c++11
 BOOST_ROOT = $(shell $(MASON) prefix boost $(BOOST_VERSION))
 BOOST_FLAGS = -isystem $(BOOST_ROOT)/include/
 RELEASE_FLAGS = -O3 -DNDEBUG -march=native -DSINGLE_THREADED -fvisibility-inlines-hidden -fvisibility=hidden
-DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer -fPIE -D_FORTIFY_SOURCE=2 -fwrapv -Wformat -Wformat-security
+DEBUG_FLAGS = -O0 -g -DDEBUG -fno-inline-functions -fno-omit-frame-pointer -fPIE
+WARNING_FLAGS = -Werror -Wall -Wextra -pedantic \
+		-Wformat=2 -Wsign-conversion -Wshadow -Wunused-parameter
+
 COMMON_FLAGS = -std=$(CXX_STD)
-
-WARNING_FLAGS = -Wall -Werror -pedantic -Wextra -Wsign-compare -Wsign-conversion -Wshadow -Wunused-parameter
-CLANG_WARNING_FLAGS = -Wno-unsequenced -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors
-ifneq (,$(findstring clang,$(CXX)))
-    WARNING_FLAGS += $(CLANG_WARNING_FLAGS)
-endif
-
 COMMON_FLAGS += $(WARNING_FLAGS)
 
 CXXFLAGS := $(CXXFLAGS)


### PR DESCRIPTION
refs #133 

-D_FORTIFY_SOURCE has no effect under -O0
    And there's nothing in this repo that _FORTIFY_SOURCE would check.

-fwrapv is a code-generation option
    Variant, being a header-only library, should work with or without
    this, and indeed will, because it doesn't rely on signed overflow
    behavior. For the sake of testing, it makes more sense to test in
    standard-compliant conditions, i.e. without -fwrapv.

-Wsign-compare is already enabled by -Wall -Wextra

-Wformat-security can be enabled by -Wformat=2

-Wno-unsequenced is unacceptable, unless there's a strong reason for it
    Note that any warnings suppressed here will pop up in user code
    using the library, and this one in particular should not be casually
    suppressed.

The rest of CLANG_WARNING_FLAGS are redundant, as these warnings aren't
enabled by default, nor by -Wall -Wextra.