### PR TITLE
Making a sizeof(variant) match `boost` and `std` implementation 

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -84,7 +84,15 @@ protected:
     ~static_visitor() {}
 };
 
+#if !defined(MAPBOX_VARIANT_MINIMIZE_SIZE)
 using type_index_t = unsigned int;
+#else
+#if defined(MAPBOX_VARIANT_OPTIMIZE_FOR_SPEED)
+using type_index_t = std::uint_fast8_t;
+#else
+using type_index_t = std::uint_least8_t;
+#endif
+#endif
 
 namespace detail {
 
@@ -587,7 +595,7 @@ public:
     VARIANT_INLINE variant() noexcept(std::is_nothrow_default_constructible<first_type>::value)
         : type_index(sizeof...(Types)-1)
     {
-        static_assert(std::is_default_constructible<first_type>::value, "First type in variant must be default constructible to allow default construction of variant");
+        static_assert(std::is_default_constructible<first_type>::value, "First type in variant must be default constructible to allow default construction of variant.");
         new (&data) first_type();
     }
 

--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -11,6 +11,7 @@
 #include <typeinfo>
 #include <utility>
 #include <functional>
+#include <limits>
 
 #include <mapbox/recursive_wrapper.hpp>
 #include <mapbox/variant_visitor.hpp>

--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -565,9 +565,10 @@ struct no_init {};
 template <typename... Types>
 class variant
 {
-    static_assert(sizeof...(Types) > 0, "Template parameter type list of variant can not be empty");
+    static_assert(sizeof...(Types) > 0, "Template parameter type list of variant can not be empty.");
     static_assert(!detail::disjunction<std::is_reference<Types>...>::value, "Variant can not hold reference types. Maybe use std::reference_wrapper?");
-    static_assert(sizeof...(Types) < std::numeric_limits<type_index_t>::max(), "Internal index type must be able to accommodate all alternatives");
+    static_assert(!detail::disjunction<std::is_array<Types>...>::value, "Variant can not hold array types.");
+    static_assert(sizeof...(Types) < std::numeric_limits<type_index_t>::max(), "Internal index type must be able to accommodate all alternatives.");
 private:
     static const std::size_t data_size = detail::static_max<sizeof(Types)...>::value;
     static const std::size_t data_align = detail::static_max<alignof(Types)...>::value;

--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -560,16 +560,14 @@ struct hasher
 
 } // namespace detail
 
-struct no_init
-{
-};
+struct no_init {};
 
 template <typename... Types>
 class variant
 {
     static_assert(sizeof...(Types) > 0, "Template parameter type list of variant can not be empty");
     static_assert(!detail::disjunction<std::is_reference<Types>...>::value, "Variant can not hold reference types. Maybe use std::reference_wrapper?");
-
+    static_assert(sizeof...(Types) < std::numeric_limits<type_index_t>::max(), "Internal index type must be able to accommodate all alternatives");
 private:
     static const std::size_t data_size = detail::static_max<sizeof(Types)...>::value;
     static const std::size_t data_align = detail::static_max<alignof(Types)...>::value;

--- a/test/t/sizeof.cpp
+++ b/test/t/sizeof.cpp
@@ -1,4 +1,3 @@
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -15,7 +14,7 @@ struct some_struct
     std::string c;
 };
 
-using variant_internal_index_type = size_t;
+using variant_internal_index_type = mapbox::util::type_index_t;
 
 TEST_CASE("size of variants")
 {


### PR DESCRIPTION
by storing internal type_index as `unsigned int`