### PR TITLE
add large tree-variant benchmark

### DIFF
--- a/test/recursive_wrapper_test.cpp
+++ b/test/recursive_wrapper_test.cpp
@@ -92,6 +92,30 @@ struct to_string
     }
 };
 
+void bench_large_expression(std::size_t num)
+{
+    std::cerr << "----- sum of " << num << " ones -----" << std::endl;
+    expression sum = 0;
+    {
+        std::cerr << "construction ";
+        auto_cpu_timer t;
+        for (std::size_t i = 0; i < num; ++i)
+        {
+            sum = binary_op<add>(std::move(sum), 1);
+        }
+    }
+    int total = 0;
+    {
+        std::cerr << "calculation ";
+        auto_cpu_timer t;
+        for (std::size_t i = 0; i < num; ++i)
+        {
+            total += util::apply_visitor(calculator(), sum);
+        }
+    }
+    std::cerr << "total=" << total << std::endl;
+}
+
 } // namespace test
 
 int main(int argc, char** argv)
@@ -120,6 +144,9 @@ int main(int argc, char** argv)
     std::cerr << "total=" << total << std::endl;
 
     std::cerr << util::apply_visitor(test::to_string(), result) << "=" << util::apply_visitor(test::calculator(), result) << std::endl;
+
+    test::bench_large_expression(1000);
+    test::bench_large_expression(5000);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
```
out/recursive_wrapper_test 321000000
TYPE OF RESULT-> TYPE_ID=N4test9binary_opINS_3subEEE
1542000us
total=321000000
2+3-4=1
----- sum of 1000 ones -----
construction 57397us
calculation 7377us
total=1000000
----- sum of 5000 ones -----
construction 1485368us
calculation 256442us
total=25000000
```

```
out/unique_ptr_test 321000000
TYPE OF RESULT-> TYPE_ID=St10unique_ptrIN4test9binary_opINS0_3subEEESt14default_deleteIS3_EE
840123us
total=321000000
2+3-4=1
----- sum of 1000 ones -----
construction 41us
calculation 5986us
total=1000000
----- sum of 5000 ones -----
construction 171us
calculation 182640us
total=25000000
```

Look at the times for "construction" of large trees.
With `recursive_wrapper` a 5x increase in tree size results in `1485368 / 57397 > 25x` increase in running time.
With `unique_ptr` the increase in running time is only `171 / 41 > 4x`.

There's one strange surprise, though. The first timing below TYPE is from an existing calculation test, and `unique_ptr` is almost twice as fast after the change (which doesn't touch any of that code), whereas before the change, there was no difference:
```
out/recursive_wrapper_test 321000000
TYPE OF RESULT-> TYPE_ID=N4test9binary_opINS_3subEEE
844526us
total=321000000
2+3-4=1
```

```
out/unique_ptr_test 321000000
TYPE OF RESULT-> TYPE_ID=St10unique_ptrIN4test9binary_opINS0_3subEEESt14default_deleteIS3_EE
844189us
total=321000000
2+3-4=1
```

That's with `gcc-6.2`. I previously tried with 4.8 and 5.4 and there were differences but not really convincing; `recursive_wrapper` was faster, then I slightly changed the code to only construct one `test::calculator` instead of constructing temporaries for every operation, and suddenly `unique_ptr` was faster; then I reverted that change, added the `bench_large_tree` function (without calling it) and the times were almost identical.
