### PR TITLE
Failing Test Case: std::move-ing out of variant

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -178,34 +178,16 @@ struct value_traits
     using target_type = typename std::tuple_element<tindex, std::tuple<void, Types...>>::type;
 };
 
-template <typename T, typename R = void>
-struct enable_if_type
-{
-    using type = R;
-};
-
-template <typename F, typename V, typename Enable = void>
+template <typename F, typename V>
 struct result_of_unary_visit
 {
-    using type = typename std::result_of<F(V&)>::type;
+    using type = decltype(::std::declval<F>()(::std::declval<V>()));
 };
 
 template <typename F, typename V>
-struct result_of_unary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
-{
-    using type = typename F::result_type;
-};
-
-template <typename F, typename V, typename Enable = void>
 struct result_of_binary_visit
 {
-    using type = typename std::result_of<F(V&, V&)>::type;
-};
-
-template <typename F, typename V>
-struct result_of_binary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
-{
-    using type = typename F::result_type;
+    using type = decltype(::std::declval<F>()(::std::declval<V>(), (void)::std::declval<V>()));
 };
 
 template <type_index_t arg1, type_index_t... others>

--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -143,6 +143,30 @@ void test_match_overloads_otherwise()
 }
 #endif
 
+template <typename>
+struct Moveable
+{
+    Moveable() = default; // Default constructible
+
+    Moveable(const Moveable&) = delete;            // Disable copy ctor
+    Moveable& operator=(const Moveable&) = delete; // Disable copy assign op
+
+    Moveable(Moveable&&) = default;            // Enable move ctor
+    Moveable& operator=(Moveable&&) = default; // Enable move assign op
+};
+
+void test_match_move_out_of_variant()
+{
+    // Distinguishable at type level
+    using T1 = Moveable<struct Tag1>;
+    using T2 = Moveable<struct Tag2>;
+
+    mapbox::util::variant<T1, T2> v = T1{};
+
+    v.match([](T1&&) {},  // Consume T1 by value
+            [](T2&&) {}); // Consume T2 by value
+}
+
 int main()
 {
     test_lambda_overloads();
@@ -154,6 +178,7 @@ int main()
     test_match_overloads();
     test_match_overloads_capture();
     test_match_overloads_otherwise();
+    test_match_move_out_of_variant();
 }
 
 #undef HAS_CPP14_SUPPORT

--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -163,8 +163,8 @@ void test_match_move_out_of_variant()
 
     mapbox::util::variant<T1, T2> v = T1{};
 
-    v.match([](T1&&) {},  // Consume T1 by value
-            [](T2&&) {}); // Consume T2 by value
+    std::move(v).match([](T1&&) {},  // Consume T1 by value
+                       [](T2&&) {}); // Consume T2 by value
 }
 
 int main()


### PR DESCRIPTION
@anandthakker and I just had a discussion about move-ing types out of a variant.

Think:

```c++
variant<Container1, Container2> v;

v.match([](Container1&& c1) { },
        [](Container2&& c2) { });
```

Which does not compile.

I think the issue is [this type alias](https://github.com/mapbox/variant/blob/916139a2e51e125816efce6e19d428385601273f/include/mapbox/variant.hpp#L190) (and related), which do not take rvalue refs into account.