### PR TITLE
Add variant_static_cast, variant_dynamic_cast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,5 +166,5 @@ after_script:
     make coverage;
     ./out/cov-test;
     cp unit*gc* test/;
-    ./.local/bin/cpp-coveralls --gcov /usr/bin/llvm-cov-3.5 --gcov-options '\-lp' -i optional.hpp -i recursive_wrapper.hpp -i variant.hpp -i variant_io.hpp;
+    ./.local/bin/cpp-coveralls --gcov /usr/bin/llvm-cov-3.5 --gcov-options '\-lp' -i optional.hpp -i recursive_wrapper.hpp -i variant.hpp -i variant_io.hpp variant_cast.hpp;
    fi

--- a/include/mapbox/variant_cast.hpp
+++ b/include/mapbox/variant_cast.hpp
@@ -1,0 +1,85 @@
+#ifndef VARIANT_CAST_HPP
+#define VARIANT_CAST_HPP
+
+#include <type_traits>
+
+namespace mapbox {
+namespace util {
+
+namespace detail {
+
+template <class T>
+class static_caster
+{
+public:
+    template <class V>
+    T& operator()(V& v) const
+    {
+        return static_cast<T&>(v);
+    }
+};
+
+template <class T>
+class dynamic_caster
+{
+public:
+    using result_type = T&;
+    template <class V>
+    T& operator()(V& v, typename std::enable_if<!std::is_polymorphic<V>::value>::type* = nullptr) const
+    {
+        throw std::bad_cast();
+    }
+    template <class V>
+    T& operator()(V& v, typename std::enable_if<std::is_polymorphic<V>::value>::type* = nullptr) const
+    {
+        return dynamic_cast<T&>(v);
+    }
+};
+
+template <class T>
+class dynamic_caster<T*>
+{
+public:
+    using result_type = T*;
+    template <class V>
+    T* operator()(V& v, typename std::enable_if<!std::is_polymorphic<V>::value>::type* = nullptr) const
+    {
+        return nullptr;
+    }
+    template <class V>
+    T* operator()(V& v, typename std::enable_if<std::is_polymorphic<V>::value>::type* = nullptr) const
+    {
+        return dynamic_cast<T*>(&v);
+    }
+};
+}
+
+template <class T, class V>
+typename detail::dynamic_caster<T>::result_type
+dynamic_variant_cast(V& v)
+{
+    return mapbox::util::apply_visitor(detail::dynamic_caster<T>(), v);
+}
+
+template <class T, class V>
+typename detail::dynamic_caster<const T>::result_type
+dynamic_variant_cast(const V& v)
+{
+    return mapbox::util::apply_visitor(detail::dynamic_caster<const T>(), v);
+}
+
+template <class T, class V>
+T& static_variant_cast(V& v)
+{
+    return mapbox::util::apply_visitor(detail::static_caster<T>(), v);
+}
+
+template <class T, class V>
+const T& static_variant_cast(const V& v)
+{
+    return mapbox::util::apply_visitor(detail::static_caster<const T>(), v);
+}
+}
+}
+
+#endif // VARIANT_CAST_HPP


### PR DESCRIPTION
```
class Base {public: virtual ~Base(){}};
class A: public Base {};
class B: public Base {};

typedef mapbox::util::variant<A, B> T;
T t = A();
auto &base = mapbox::util::variant_static_cast<Base>(t);
auto &a = mapbox::util::variant_dynamic_cast<A>(t);
auto &b = mapbox::util::variant_dynamic_cast<B>(t); //throws std:bad_cast
auto *aPtr = mapbox::util::variant_dynamic_cast<A*>(t);
auto *bPtr = mapbox::util::variant_dynamic_cast<B*>(t); //bPtr == nullptr
```