### PR TITLE
Improve Boost Build support

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -31,46 +31,31 @@ project mapbox_variant
       <threading>single
     ;
 
-exe variant-test
-    : test/bench_variant.cpp
+rule exe-test ( name : reqs * : deps * )
+{
+    exe $(name)
+        : test/$(name).cpp
+        : $(reqs)
+        : $(deps)
+        ;
+    explicit $(name) ;
+}
+
+exe-test bench_variant
     : <variant>release:<cxxflags>-Wweak-vtables
     ;
-explicit variant-test ;
 
-exe binary-visitor-test
-    : test/binary_visitor_test.cpp
-    ;
-explicit binary-visitor-test ;    
-
-exe recursive-wrapper-test
-    : test/recursive_wrapper_test.cpp
-    ;
-explicit recursive-wrapper-test ;
-
-exe unique-ptr-test
-    : test/unique_ptr_test.cpp
-    ;
-explicit unique-ptr-test ;
-
-exe reference_wrapper_test
-    : test/reference_wrapper_test.cpp
-    ;
-explicit reference_wrapper_test ;    
-
-exe lambda_overload_test
-    : test/lambda_overload_test.cpp
-    ;
-explicit lambda_overload_test ;
-
-exe hashable_test
-    : test/hashable_test.cpp
-    ;
-explicit hashable_test ;
+exe-test binary_visitor_test ;
+exe-test recursive_wrapper_test ;
+exe-test unique_ptr_test ;
+exe-test reference_wrapper_test ;
+exe-test lambda_overload_test ;
+exe-test hashable_test ;
 
 install out
-    : variant-test
-      binary-visitor-test
-      unique-ptr-test
+    : bench_variant
+      binary_visitor_test
+      unique_ptr_test
       reference_wrapper_test
       lambda_overload_test
       hashable_test

--- a/Jamroot
+++ b/Jamroot
@@ -3,7 +3,11 @@
 
 import os ;
 
-local BOOST_DIR = "/usr/local" ;
+local boost_dir = [ os.environ BOOST_DIR ] ;
+if ! $(boost_dir)
+{
+    boost_dir = "/usr/local" ;
+}
 
 #using clang : : ;
 
@@ -16,19 +20,20 @@ if ! $(cxx_std)
 project mapbox_variant
     : requirements
       <cxxflags>-std=$(cxx_std)
-      <include>$(BOOST_DIR)/include
+      <include>$(boost_dir)/include
       <include>include
       <include>test/include
       <variant>release:<cxxflags>-march=native
+      <threading>single:<define>SINGLE_THREADED
     : default-build
       <variant>release
       <optimization>speed
+      <threading>single
     ;
 
 exe variant-test
     : test/bench_variant.cpp
-    : #<define>SINGLE_THREADED
-      <variant>release:<cxxflags>-Wweak-vtables
+    : <variant>release:<cxxflags>-Wweak-vtables
     ;
 explicit variant-test ;
 
@@ -52,10 +57,21 @@ exe reference_wrapper_test
     ;
 explicit reference_wrapper_test ;    
 
+exe lambda_overload_test
+    : test/lambda_overload_test.cpp
+    ;
+explicit lambda_overload_test ;
+
+exe hashable_test
+    : test/hashable_test.cpp
+    ;
+explicit hashable_test ;
+
 install out
     : variant-test
       binary-visitor-test
-      recursive-wrapper-test
       unique-ptr-test
       reference_wrapper_test
+      lambda_overload_test
+      hashable_test
     ;   

--- a/Jamroot
+++ b/Jamroot
@@ -1,78 +1,65 @@
 # Unofficial and incomplete build file using Boost build system.
 # You should use make unless you know what you are doing.
 
+import os ;
+
 local BOOST_DIR = "/usr/local" ;
 
 #using clang : : ;
+
+local cxx_std = [ os.environ CXX_STD ] ;
+if ! $(cxx_std)
+{
+    cxx_std = c++11 ;
+}
 
 lib system : : <name>boost_system <search>$(BOOST_DIR)/lib ;
 lib timer : chrono : <name>boost_timer <search>$(BOOST_DIR)/lib ;
 lib chrono : system : <name>boost_chrono <search>$(BOOST_DIR)/lib ;
 
-exe variant-test
-    :
-    test/bench_variant.cpp
-    .//system
-    .//timer
-    .//chrono
-    :
-    <include>$(BOOST_DIR)/include
-    <include>./include
-    <include>./test/include
-    #<define>SINGLE_THREADED
-    <variant>release:<cxxflags>"-march=native -Wweak-vtables"
+project mapbox_variant
+    : requirements
+      <cxxflags>-std=$(cxx_std)
+      <include>$(BOOST_DIR)/include
+      <include>./include
+      <include>./test/include
+      <library>system
+      <library>timer
+      <library>chrono
+      <variant>release:<cxxflags>-march=native
     ;
 
+exe variant-test
+    : test/bench_variant.cpp
+    : #<define>SINGLE_THREADED
+      <variant>release:<cxxflags>-Wweak-vtables
+    ;
+explicit variant-test ;
 
 exe binary-visitor-test
-    :
-    test/binary_visitor_test.cpp
-    .//system
-    .//timer
-    .//chrono
-    :
-    <include>$(BOOST_DIR)/include
-    <include>./include
-    <include>./test/include
-    <variant>release:<cxxflags>-march=native
+    : test/binary_visitor_test.cpp
     ;
+explicit binary-visitor-test ;    
 
 exe recursive-wrapper-test
-    :
-    test/recursive_wrapper_test.cpp
-    .//system
-    .//timer
-    .//chrono
-    :
-    <include>$(BOOST_DIR)/include
-    <include>./include
-    <include>./test/include
-    <variant>release:<cxxflags>-march=native
+    : test/recursive_wrapper_test.cpp
     ;
+explicit recursive-wrapper-test ;
 
 exe unique-ptr-test
-    :
-    test/unique_ptr_test.cpp
-    .//system
-    .//timer
-    .//chrono
-    :
-    <include>$(BOOST_DIR)/include
-    <include>./include
-    <include>./test/include
-    <variant>release:<cxxflags>-march=native
+    : test/unique_ptr_test.cpp
     ;
-
+explicit unique-ptr-test ;
 
 exe reference_wrapper_test
-    :
-    test/reference_wrapper_test.cpp
-    .//system
-    .//timer
-    .//chrono
-    :
-    <include>$(BOOST_DIR)/include
-    <include>./include
-    <include>./test/include
-    <variant>release:<cxxflags>-march=native
+    : test/reference_wrapper_test.cpp
     ;
+explicit reference_wrapper_test ;    
+
+install out
+    : variant-test
+      binary-visitor-test
+      recursive-wrapper-test
+      unique-ptr-test
+      reference_wrapper_test
+    ;   

--- a/Jamroot
+++ b/Jamroot
@@ -13,20 +13,16 @@ if ! $(cxx_std)
     cxx_std = c++11 ;
 }
 
-lib system : : <name>boost_system <search>$(BOOST_DIR)/lib ;
-lib timer : chrono : <name>boost_timer <search>$(BOOST_DIR)/lib ;
-lib chrono : system : <name>boost_chrono <search>$(BOOST_DIR)/lib ;
-
 project mapbox_variant
     : requirements
       <cxxflags>-std=$(cxx_std)
       <include>$(BOOST_DIR)/include
-      <include>./include
-      <include>./test/include
-      <library>system
-      <library>timer
-      <library>chrono
+      <include>include
+      <include>test/include
       <variant>release:<cxxflags>-march=native
+    : default-build
+      <variant>release
+      <optimization>speed
     ;
 
 exe variant-test


### PR DESCRIPTION
Hi,

I made some improvements to support the Boost Build usage. I took a look at `Makefile` to try reflecting the following:
1. Usage of `CXX_STD` environment variable;
1. Usage of `SINGLE_THREADED` macro at single threading mode;
1. Release, single threading, optimization and `CXX_STD=-std=c++11` as default build;
1. Adding `lambda_overload_test` and `hashable_test`;
1. Removing boost bynary dependencies: `boost_system`, `boost_timer` and `boost_chrono`;
1. Usage of `out` directory to put the built targets.

The `BOOST_DIR` can now be passed through command line:
```
b2 -sBOOST_DIR=$(BOOST)
```
or
```
BOOST_DIR=$(BOOST) b2
```
*Note: The same is valid to `CXX_STD`.*

Common flags and options are in a project section and a rule `exe-test` was created to reduce de boilerplate code.
