### PR TITLE
Add move semantics to make_visitor and visitor

### DIFF
--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -118,14 +118,20 @@ void test_match_overloads_capture()
 struct MovableOnly
 {
     MovableOnly() = default;
+    
     MovableOnly(MovableOnly&&) = default;
+    MovableOnly& operator=(MovableOnly&&) = default;
 };
 
 struct MovableCopyable
 {
     MovableCopyable() = default;
+    
     MovableCopyable(MovableCopyable&&) = default;
+    MovableCopyable& operator=(MovableCopyable&&) = default;
+    
     MovableCopyable(const MovableCopyable&) = default;
+    MovableCopyable& operator=(const MovableCopyable&) = default;
 };
 
 void test_match_overloads_init_capture()


### PR DESCRIPTION
Hi,

This pull request adds move semantics support to avoid unnecessary internal copies
of closures passed to `make_visitor` and it permits the usage of **init
capture**(feature of C++14) to use movable-only types. It also adds a
test case for lambda with init capture and movable(but not copyable)
object.

### Before this:
```c++
struct movable_and_copyable
{
    movable_and_copyable() = default;
    movable_and_copyable(movable_and_copyable&&)
    { std::cout << "move ctor" << std::endl; }
    movable_and_copyable(const movable_and_copyable&) 
    { std::cout << "copy ctor" << std::endl; }
};

struct movable_only
{
    movable_only() = default;
    movable_only(movable_only&&) = default;
};

int main()
{
    mapbox::util::variant<int, double> variant;
    movable_and_copyable obj;
    variant.match([obj](auto&&){});


    // This legal C++14 code doesn't compile.
    // movable_only movable_only_obj;
    // variant.match([p = std::move(movable_only_obj)](auto&&){});
}
```
Output:
```
copy ctor
move ctor
copy ctor
copy ctor
```
