### PR TITLE
Fix the noexcept specifications for move assignment and conversion.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ out/%.o: test/t/%.cpp Makefile $(ALL_HEADERS)
 	mkdir -p ./out
 	$(CXX) -c -o $@ $< -Iinclude -isystem test/include $(FINAL_CXXFLAGS)
 
-out/unit: out/unit.o out/binary_visitor_1.o out/binary_visitor_2.o out/binary_visitor_3.o out/binary_visitor_4.o out/binary_visitor_5.o out/binary_visitor_6.o out/issue21.o out/issue122.o out/mutating_visitor.o out/optional.o out/recursive_wrapper.o out/sizeof.o out/unary_visitor.o out/variant.o out/variant_alternative.o
+out/unit: out/unit.o out/binary_visitor_1.o out/binary_visitor_2.o out/binary_visitor_3.o out/binary_visitor_4.o out/binary_visitor_5.o out/binary_visitor_6.o out/issue21.o out/issue122.o out/mutating_visitor.o out/optional.o out/recursive_wrapper.o out/sizeof.o out/unary_visitor.o out/variant.o out/variant_alternative.o out/nothrow_move.o
 	mkdir -p ./out
 	$(CXX) -o $@ $^ $(LDFLAGS)
 

--- a/test/t/nothrow_move.cpp
+++ b/test/t/nothrow_move.cpp
@@ -1,0 +1,66 @@
+#include <typeinfo>
+#include <utility>
+
+#include <mapbox/variant.hpp>
+
+using namespace mapbox;
+
+namespace test {
+
+struct t_noexcept_true_1 {
+  t_noexcept_true_1(t_noexcept_true_1&&) noexcept = default;
+  t_noexcept_true_1& operator=(t_noexcept_true_1&&) noexcept = default;
+};
+
+struct t_noexcept_true_2 {
+  t_noexcept_true_2(t_noexcept_true_2&&) noexcept = default;
+  t_noexcept_true_2& operator=(t_noexcept_true_2&&) noexcept = default;
+};
+
+struct t_noexcept_false_1 {
+  t_noexcept_false_1(t_noexcept_false_1&&) noexcept(false) {}
+  t_noexcept_false_1& operator=(t_noexcept_false_1&&) noexcept(false) { return *this; }
+};
+
+using should_be_no_throw_copyable = util::variant<t_noexcept_true_1, t_noexcept_true_2>;
+static_assert(std::is_nothrow_move_assignable<should_be_no_throw_copyable>::value,
+              "variants with no-throw move assignable types should be "
+              "no-throw move nothrow assignable");
+
+using should_be_no_throw_assignable = util::variant<t_noexcept_true_1, t_noexcept_true_2>;
+static_assert(std::is_nothrow_move_constructible<should_be_no_throw_assignable>::value,
+              "variants with no-throw move assignable types should be "
+              "no-throw move nothrow assignable");
+
+using should_not_be_no_throw_copyable = util::variant<t_noexcept_true_1, t_noexcept_false_1>;
+static_assert(not std::is_nothrow_move_assignable<should_not_be_no_throw_copyable>::value,
+              "variants with no-throw move assignable types should be "
+              "no-throw move nothrow assignable");
+
+using should_not_be_no_throw_assignable = util::variant<t_noexcept_true_1, t_noexcept_false_1>;
+static_assert(not std::is_nothrow_move_constructible<should_not_be_no_throw_assignable>::value,
+              "variants with no-throw move assignable types should be "
+              "no-throw move nothrow assignable");
+
+
+// this type cannot be nothrow converted from either of its types, even the nothrow moveable one,
+// because the conversion operator moves the whole variant.
+using convertable_test_type = util::variant<t_noexcept_true_1, t_noexcept_false_1>;
+
+// this type can be nothrow converted from either of its types.
+using convertable_test_type_2 = util::variant<t_noexcept_true_1, t_noexcept_true_2>;
+
+static_assert(not std::is_nothrow_assignable<convertable_test_type, t_noexcept_true_1>::value,
+              "variants with noexcept(true) move constructible types should be nothrow-convertible "
+              "from those types only IF the variant itself is nothrow_move_assignable");
+
+static_assert(not std::is_nothrow_assignable<convertable_test_type, t_noexcept_false_1>::value,
+              "variants with noexcept(false) move constructible types should not be nothrow-convertible "
+              "from those types");
+
+static_assert(std::is_nothrow_assignable<convertable_test_type_2, t_noexcept_true_2>::value,
+              "variants with noexcept(true) move constructible types should be nothrow-convertible "
+              "from those types only IF the variant itself is nothrow_move_assignable");
+
+
+} // namespace test


### PR DESCRIPTION
This should allow variants to be nothrow move-assignable where appropriate.

I also took a crack at fixing the noexcept spec on the conversion assignment operator, which could previously lie. I definitely don't understand the meta-programming used here, so comments are welcome.