### PR TITLE
Removes deprecated static_visitor to avoid msvc C4996 compiler warning

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -75,16 +75,6 @@ public:
 
 }; // class bad_variant_access
 
-template <typename R = void>
-struct MAPBOX_VARIANT_DEPRECATED static_visitor
-{
-    using result_type = R;
-
-protected:
-    static_visitor() {}
-    ~static_visitor() {}
-};
-
 #if !defined(MAPBOX_VARIANT_MINIMIZE_SIZE)
 using type_index_t = unsigned int;
 #else


### PR DESCRIPTION
We're getting annoying C4996 msvc compiler warning stating that deprecated constraint is found by compiler("was declared deprecated"). In combination with compiler flag to treat any warning as error it fails CI builds. Can we just remove deprecated `static_visitor`? Thanks