### PR TITLE
Support for empty class serialization

### DIFF
--- a/include/mapbox/variant_io.hpp
+++ b/include/mapbox/variant_io.hpp
@@ -2,6 +2,7 @@
 #define MAPBOX_UTIL_VARIANT_IO_HPP
 
 #include <iosfwd>
+#include <type_traits>
 
 #include <mapbox/variant.hpp>
 
@@ -20,7 +21,14 @@ public:
 
     // visitor
     template <typename T>
-    void operator()(T const& operand) const
+    typename std::enable_if<std::is_empty<T>::value, void>::type operator()(T const&) const
+    {
+        out_ << "[]";
+    }
+
+    // visitor
+    template <typename T>
+    typename std::enable_if<!std::is_empty<T>::value, void>::type operator()(T const& operand) const
     {
         out_ << operand;
     }

--- a/test/t/variant.cpp
+++ b/test/t/variant.cpp
@@ -362,12 +362,12 @@ TEST_CASE("variant default constructor", "[variant][default constructor]")
 
 TEST_CASE("variant printer", "[visitor][unary visitor][printer]")
 {
-    using variant_type = mapbox::util::variant<int, double, std::string>;
-    std::vector<variant_type> var = {2.1, 123, "foo", 456};
+    using variant_type = mapbox::util::variant<int, double, std::string, dummy>;
+    std::vector<variant_type> var = {2.1, 123, "foo", 456, dummy()};
     std::stringstream out;
     std::copy(var.begin(), var.end(), std::ostream_iterator<variant_type>(out, ","));
     out << var[2];
-    REQUIRE(out.str() == "2.1,123,foo,456,foo");
+    REQUIRE(out.str() == "2.1,123,foo,456,[],foo");
 }
 
 TEST_CASE("swapping variants should do the right thing", "[variant]")


### PR DESCRIPTION
This allows serialization of empty class types, such as geometry.hpp's [empty](https://github.com/mapbox/geometry.hpp/pull/60) class.