### PR TITLE
Silence warning under -Wundef

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -106,7 +106,7 @@ struct direct_type<T>
     static constexpr type_index_t index = invalid_value;
 };
 
-#if __cpp_lib_logical_traits >= 201510L
+#if defined(__cpp_lib_logical_traits) && __cpp_lib_logical_traits >= 201510L
 
 using std::conjunction;
 using std::disjunction;


### PR DESCRIPTION
This line produces an undefined value warning when compiling in pre-C++17 mode with `-Wundef` turned on.