### PR TITLE
pass rvalue reference to visitor when visiting an rvalue variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,20 +90,6 @@ matrix:
           sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6' ]
           packages: [ 'clang-3.6' ]
     - os: linux
-      compiler: "clang37"
-      env: CXX=clang++-3.7
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7' ]
-          packages: [ 'clang-3.7' ]
-    - os: linux
-      compiler: "gcc47"
-      env: CXX=g++-4.7 CXXFLAGS="-Wno-parentheses"
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'g++-4.7' ]
-    - os: linux
       compiler: "gcc48"
       env: CXX=g++-4.8
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ install:
 
 script:
  # Build in Release
+ - make
  - make test
  - make bench
  - make sizes
@@ -138,6 +139,7 @@ script:
  - make clean;
  # Build in Debug
  - export BUILDTYPE=Debug
+ - make
  - make test
  - make bench
  - make sizes

--- a/test/compilation_failure/get_type.cpp
+++ b/test/compilation_failure/get_type.cpp
@@ -1,4 +1,4 @@
-// @EXPECTED: enable_if
+// @EXPECTED: no matching .*\<function for call to .*\<get\>
 
 #include <mapbox/variant.hpp>
 

--- a/test/compilation_failure/mutating_visitor_on_const.cpp
+++ b/test/compilation_failure/mutating_visitor_on_const.cpp
@@ -1,4 +1,4 @@
-// @EXPECTED: const int
+// @EXPECTED: no matching function for call to .*\<apply_visitor\>
 
 #include <mapbox/variant.hpp>
 

--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -10,6 +10,15 @@
 
 using namespace mapbox::util;
 
+template <typename T>
+struct tag
+{
+    static void dump(const char* prefix)
+    {
+        std::cout << prefix << ": " << typeid(tag<T>).name() << std::endl;
+    }
+};
+
 template <typename Left, typename Right>
 using Either = mapbox::util::variant<Left, Right>;
 
@@ -53,6 +62,37 @@ void test_singleton_variant()
 
     variant<int> singleton;
     apply_visitor(make_visitor([](int) {}), singleton);
+}
+
+// See #180
+struct test_call_nonconst_member_visitor
+{
+    template <typename T>
+    void operator() (T & obj) const
+    {
+        tag<decltype(obj)>::dump("test_call_nonconst_member: visitor");
+        obj.foo();
+    }
+};
+
+void test_call_nonconst_member()
+{
+    struct object
+    {
+        void foo() { val = 42;}
+        int val = 0;
+    };
+
+    variant<object> v = object{};
+    apply_visitor(test_call_nonconst_member_visitor{}, v);
+
+#ifdef HAS_CPP14_SUPPORT
+    apply_visitor([](auto& obj)
+                  {
+                      tag<decltype(obj)>::dump("test_call_nonconst_member: lambda");
+                      obj.foo();
+                  }, v);
+#endif
 }
 
 void test_lambda_overloads_sfinae()
@@ -227,6 +267,7 @@ int main()
 {
     test_lambda_overloads();
     test_singleton_variant();
+    test_call_nonconst_member();
     test_lambda_overloads_capture();
     test_lambda_overloads_sfinae();
 

--- a/test/lambda_overload_test.cpp
+++ b/test/lambda_overload_test.cpp
@@ -193,6 +193,36 @@ void test_match_overloads_otherwise()
 }
 #endif
 
+template <typename>
+struct Moveable
+{
+    Moveable() = default; // Default constructible
+
+    Moveable(const Moveable&) = delete;            // Disable copy ctor
+    Moveable& operator=(const Moveable&) = delete; // Disable copy assign op
+
+    Moveable(Moveable&&) = default;            // Enable move ctor
+    Moveable& operator=(Moveable&&) = default; // Enable move assign op
+};
+
+void test_match_move_out_of_variant()
+{
+    // Distinguishable at type level
+    using T1 = Moveable<struct Tag1>;
+    using T2 = Moveable<struct Tag2>;
+    using T3 = mapbox::util::recursive_wrapper<int>;
+
+    mapbox::util::variant<T1, T2> v = T1{};
+
+    std::move(v).match([](T1&&) {},  // Consume T1 by value
+                       [](T2&&) {}); // Consume T2 by value
+
+    mapbox::util::variant<T3, T2> w = T2{};
+
+    std::move(w).match([](int&&) {}, // Consume unwrapped int
+                       [](T2&&) {}); // Consume T2 by value
+}
+
 int main()
 {
     test_lambda_overloads();
@@ -205,6 +235,7 @@ int main()
     test_match_overloads_capture();
     test_match_overloads_init_capture();
     test_match_overloads_otherwise();
+    test_match_move_out_of_variant();
 }
 
 #undef HAS_CPP14_SUPPORT

--- a/test/t/optional.cpp
+++ b/test/t/optional.cpp
@@ -1,4 +1,3 @@
-
 #include "catch.hpp"
 
 #include <mapbox/optional.hpp>
@@ -97,6 +96,8 @@ TEST_CASE("self assignment", "[optional]")
 
     a = 1;
     REQUIRE(a.get() == 1);
+#if !defined(__clang__)
     a = a;
     REQUIRE(a.get() == 1);
+#endif
 }


### PR DESCRIPTION
Fixes #142 
A note about the admittedly awkward syntax `std::move(var).match(...)`

This branch includes a change to `apply_visitor` which I forgot to put in a separate commit. Here's the deal:
```c++
mapbox::util::variant<int> v{42};
auto f = mapbox::util::make_visitor(
    [](int&) { std::cout << "lvalue\n"; },
    [](int&&) { std::cout << "rvalue\n"; });

mapbox::util::apply_visitor(f, v); // should print "lvalue"
mapbox::util::apply_visitor(f, std::move(v)); // should print "rvalue"

v.match(f); // what should this print?
```

Now, if you wanted this to work:
```c++
v.match([](int&&) { ... });
```
... you'd need to either
a) delegate to `visit(std::move(*this), fn)`, which might have surprising behaviour (using the visitor from the above example, `v.match(f)` would print "rvalue"); or
b) implement special logic for this case that'd only `std::move(stored_alternative)` if the visitor doesn't accept it by lvalue

a) is basically  a design decision, and b) sounds non-trivial; so in order to keep it simple, I chose to do neither. Thence the required `std::move(var).match(...)` syntax.
