### PR TITLE
Fixed to work with Visual Studio 2017 Express

### DIFF
--- a/include/mapbox/variant.hpp
+++ b/include/mapbox/variant.hpp
@@ -520,7 +520,7 @@ class variant
     static_assert(sizeof...(Types) > 0, "Template parameter type list of variant can not be empty.");
     static_assert(!detail::disjunction<std::is_reference<Types>...>::value, "Variant can not hold reference types. Maybe use std::reference_wrapper?");
     static_assert(!detail::disjunction<std::is_array<Types>...>::value, "Variant can not hold array types.");
-    static_assert(sizeof...(Types) < std::numeric_limits<type_index_t>::max(), "Internal index type must be able to accommodate all alternatives.");
+    static_assert(sizeof...(Types) < (std::numeric_limits<type_index_t>::max)(), "Internal index type must be able to accommodate all alternatives.");
 private:
     static const std::size_t data_size = detail::static_max<sizeof(Types)...>::value;
     static const std::size_t data_align = detail::static_max<alignof(Types)...>::value;


### PR DESCRIPTION
Compiling in Windows with Visual Studio has a well known problem that they have MIN and MAX macros that conflict with other functions in the standard library like `std::numeric_limits<T>::max` and `std::numeric_limits<T>::min`. The standard portable solution is to wrap the function call in parentheses `(std::numeric_limits<T>::max)`.